### PR TITLE
Added pointer dereferencing for field extraction

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -130,6 +130,11 @@ var evalTests = []evalTest{
 		true,
 	},
 	{
+		`Foo.Bar`,
+		&struct{ Foo *struct{ Bar bool } }{Foo: &struct{ Bar bool }{Bar: true}},
+		true,
+	},
+	{
 		"foo[2]",
 		map[string]interface{}{"foo": []rune{'a', 'b', 'c'}},
 		'c',
@@ -163,6 +168,29 @@ var evalTests = []evalTest{
 		true,
 	},
 	{
+		`[true][A]`,
+		&struct{ A int }{0},
+		true,
+	},
+	{
+		`A-1`,
+		&struct{ A int }{1},
+		float64(0),
+	},
+	{
+		`A == 0`,
+		&struct{ A uint8 }{0},
+		true,
+	},
+	{
+		`A == B`,
+		&struct {
+			A uint8
+			B float64
+		}{1, 1},
+		true,
+	},
+	{
 		`5 in 0..9`,
 		nil,
 		true,
@@ -185,6 +213,11 @@ var evalTests = []evalTest{
 	{
 		"foo['bar'].baz",
 		map[string]interface{}{"foo": map[string]interface{}{"bar": map[string]interface{}{"baz": true}}},
+		true,
+	},
+	{
+		"foo.Bar['baz']",
+		map[string]interface{}{"foo": &struct{ Bar map[string]interface{}}{Bar: map[string]interface{}{"baz": true}}},
 		true,
 	},
 	{

--- a/utils.go
+++ b/utils.go
@@ -90,6 +90,11 @@ func extract(from interface{}, it interface{}) (interface{}, error) {
 			if value.IsValid() && value.CanInterface() {
 				return value.Interface(), nil
 			}
+		case reflect.Ptr:
+			derefValue := reflect.ValueOf(from).Elem()
+			if derefValue.IsValid() && derefValue.CanInterface() {
+				return extract(derefValue.Interface(), it)
+			}
 		}
 	}
 	return nil, fmt.Errorf("can't get %q from %T", it, from)


### PR DESCRIPTION
Hi @antonmedv,

Saw this on Golang Weekly and though it looked pretty good.  Added a PR which dereferences pointers to structs when attempting to extract a field name so that pointers to structs can be used as data alongside regular structs.  Example:

```!go
type Data struct {
   X int
}

data := &Data{X: 123}
result, err := expr.Eval("X", data)
// result == 123
```

Hope you find it useful.

Thanks,

Leon