### PR TITLE
Add type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Inspired by
 ## Features
 
 * Works with any valid Go object (structs, maps, etc)
-* Compile-time checks for used variables
-* Сlear error messages:
+* Strict mode with type checks
+* User-friendly error messages
   ```
   unclosed "("
   (boo + bar]

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,8 +1,9 @@
-package expr
+package expr_test
 
 import (
 	"testing"
 
+	"github.com/antonmedv/expr"
 	"github.com/dop251/goja"
 	"github.com/robertkrimen/otto"
 )
@@ -30,13 +31,13 @@ func Benchmark_expr(b *testing.B) {
 		Marker: "test",
 	}
 
-	script, err := Parse(`Segments[0].Origin == "MOW" && Passengers.Adults == 2 && Marker == "test"`)
+	script, err := expr.Parse(`Segments[0].Origin == "MOW" && Passengers.Adults == 2 && Marker == "test"`)
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	for n := 0; n < b.N; n++ {
-		Run(script, r)
+		expr.Run(script, r)
 	}
 }
 

--- a/doc_test.go
+++ b/doc_test.go
@@ -16,6 +16,7 @@ func ExampleEval() {
 	}
 
 	fmt.Printf("%v", output)
+
 	// Output: hello world
 }
 
@@ -36,6 +37,7 @@ func ExampleEval_map() {
 	}
 
 	fmt.Printf("%v", output)
+
 	// Output: hello user
 }
 
@@ -54,6 +56,7 @@ func ExampleEval_struct() {
 	}
 
 	fmt.Printf("%v", output)
+
 	// Output: 42
 }
 
@@ -66,6 +69,7 @@ func ExampleEval_error() {
 	}
 
 	fmt.Printf("%v", output)
+
 	// Output: err: unclosed "("
 	//(boo + bar]
 	//----------^
@@ -80,6 +84,7 @@ func ExampleEval_matches() {
 	}
 
 	fmt.Printf("%v", output)
+
 	// Output: err: error parsing regexp: missing closing ): `a(`
 	//"a" matches "a("
 	//----------------^
@@ -106,6 +111,7 @@ func ExampleParse() {
 	}
 
 	fmt.Printf("%v", output)
+
 	// Output: true
 }
 
@@ -130,11 +136,13 @@ func ExampleRun() {
 	}
 
 	fmt.Printf("%v", output)
+
 	// Output: false
 }
 
-func ExampleNames() {
-	_, err := expr.Parse("foo + bar + baz", expr.Names("foo", "bar"))
+func ExampleDefine() {
+	var foo, bar int
+	_, err := expr.Parse("foo + bar + baz", expr.Define("foo", foo), expr.Define("bar", bar))
 
 	if err != nil {
 		fmt.Printf("err: %v", err)
@@ -142,21 +150,62 @@ func ExampleNames() {
 	}
 
 	// Output: err: unknown name baz
-	//foo + bar + baz
-	//------------^
 }
 
-func ExampleFuncs() {
-	_, err := expr.Parse("foo(bar(baz()))", expr.Funcs("foo", "bar"))
+func ExampleWith() {
+	type segment struct {
+		Origin string
+	}
+	type passengers struct {
+		Adults int
+	}
+	type request struct {
+		Segments   []*segment
+		Passengers *passengers
+		Marker     string
+		Meta       map[string]interface{}
+	}
+
+	code := `Segments[0].Origin == "MOW" && Passengers.Adults == 2 && Marker == "test" && Meta["accept"]`
+	ast, err := expr.Parse(code, expr.With(&request{}))
 
 	if err != nil {
 		fmt.Printf("err: %v", err)
 		return
 	}
 
-	// Output: err: unknown func baz
-	//foo(bar(baz()))
-	//--------^
+	r := &request{
+		Segments: []*segment{
+			{Origin: "MOW"},
+		},
+		Passengers: &passengers{
+			Adults: 2,
+		},
+		Marker: "test",
+		Meta:   map[string]interface{}{"accept": true},
+	}
+	output, err := expr.Run(ast, r)
+
+	if err != nil {
+		fmt.Printf("err: %v", err)
+		return
+	}
+
+	fmt.Printf("%v", output)
+
+	// Output: true
+}
+
+func ExampleFuncs() {
+	var foo, bar func()
+	_, err := expr.Parse("foo(bar(baz()))", expr.Define("foo", foo), expr.Define("bar", bar))
+
+	if err != nil {
+		fmt.Printf("err: %v", err)
+		return
+	}
+
+	// Output: err: unknown func baz()
 }
 
 func ExampleNode() {
@@ -168,5 +217,6 @@ func ExampleNode() {
 	}
 
 	fmt.Printf("%v", node)
+
 	// Output: foo.bar
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,10 +1,12 @@
-package expr
+package expr_test
 
 import (
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/antonmedv/expr"
 )
 
 type evalTest struct {
@@ -413,7 +415,7 @@ var evalErrorTests = []evalErrorTest{
 
 func TestEval(t *testing.T) {
 	for _, test := range evalTests {
-		actual, err := Eval(test.input, test.env)
+		actual, err := expr.Eval(test.input, test.env)
 		if err != nil {
 			t.Errorf("%s:\n%v", test.input, err)
 			continue
@@ -426,7 +428,7 @@ func TestEval(t *testing.T) {
 
 func TestEval_error(t *testing.T) {
 	for _, test := range evalErrorTests {
-		_, err := Eval(test.input, test.env)
+		_, err := expr.Eval(test.input, test.env)
 		if err == nil {
 			err = fmt.Errorf("<nil>")
 		}
@@ -464,12 +466,12 @@ func TestEval_complex(t *testing.T) {
 	}
 
 	input := `Request.User.UserAgent matches "Mozilla" && "www" in Values(Request.User.Cookies)`
-	node, err := Parse(input, Names("Request"), Funcs("Values"))
+	node, err := expr.Parse(input, expr.With(p))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := Run(node, p)
+	actual, err := expr.Run(node, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,12 +483,12 @@ func TestEval_complex(t *testing.T) {
 }
 
 func TestEval_panic(t *testing.T) {
-	node, err := Parse("foo()")
+	node, err := expr.Parse("foo()")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = Run(node, map[string]interface{}{"foo": nil})
+	_, err = expr.Run(node, map[string]interface{}{"foo": nil})
 	if err == nil {
 		err = fmt.Errorf("<nil>")
 	}

--- a/node.go
+++ b/node.go
@@ -1,9 +1,14 @@
 package expr
 
-import "regexp"
+import (
+	"regexp"
+)
 
 // Node represents items of abstract syntax tree.
-type Node interface{}
+type Node interface {
+	Type(table typesTable) (Type, error)
+	Eval(env interface{}) (interface{}, error)
+}
 
 type nilNode struct{}
 
@@ -46,12 +51,17 @@ type matchesNode struct {
 
 type propertyNode struct {
 	node     Node
-	property Node
+	property string
+}
+
+type indexNode struct {
+	node  Node
+	index Node
 }
 
 type methodNode struct {
 	node      Node
-	property  identifierNode
+	method    string
 	arguments []Node
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -71,27 +71,27 @@ var parseTests = []parseTest{
 	},
 	{
 		"foo.bar",
-		propertyNode{nameNode{"foo"}, identifierNode{"bar"}},
+		propertyNode{nameNode{"foo"}, "bar"},
 	},
 	{
 		"foo.not",
-		propertyNode{nameNode{"foo"}, identifierNode{"not"}},
+		propertyNode{nameNode{"foo"}, "not"},
 	},
 	{
 		"foo.bar()",
-		methodNode{nameNode{"foo"}, identifierNode{"bar"}, []Node{}},
+		methodNode{nameNode{"foo"}, "bar", []Node{}},
 	},
 	{
 		"foo.not()",
-		methodNode{nameNode{"foo"}, identifierNode{"not"}, []Node{}},
+		methodNode{nameNode{"foo"}, "not", []Node{}},
 	},
 	{
 		`foo.bar("arg1", 2, true)`,
-		methodNode{nameNode{"foo"}, identifierNode{"bar"}, []Node{textNode{"arg1"}, numberNode{2}, boolNode{true}}},
+		methodNode{nameNode{"foo"}, "bar", []Node{textNode{"arg1"}, numberNode{2}, boolNode{true}}},
 	},
 	{
 		"foo[3]",
-		propertyNode{nameNode{"foo"}, numberNode{3}},
+		indexNode{nameNode{"foo"}, numberNode{3}},
 	},
 	{
 		"true ? true : false",
@@ -103,7 +103,7 @@ var parseTests = []parseTest{
 	},
 	{
 		"foo.bar().foo().baz[33]",
-		propertyNode{propertyNode{methodNode{methodNode{nameNode{"foo"}, identifierNode{"bar"}, []Node{}}, identifierNode{"foo"}, []Node{}}, identifierNode{"baz"}}, numberNode{33}},
+		indexNode{propertyNode{methodNode{methodNode{nameNode{"foo"}, "bar", []Node{}}, "foo", []Node{}}, "baz"}, numberNode{33}},
 	},
 	{
 		"+0 != -0",
@@ -123,11 +123,11 @@ var parseTests = []parseTest{
 	},
 	{
 		"[1].foo",
-		propertyNode{arrayNode{[]Node{numberNode{1}}}, identifierNode{"foo"}},
+		propertyNode{arrayNode{[]Node{numberNode{1}}}, "foo"},
 	},
 	{
 		"{foo:1}.bar",
-		propertyNode{mapNode{[]pairNode{{identifierNode{"foo"}, numberNode{1}}}}, identifierNode{"bar"}},
+		propertyNode{mapNode{[]pairNode{{identifierNode{"foo"}, numberNode{1}}}}, "bar"},
 	},
 	{
 		"len(foo)",

--- a/print.go
+++ b/print.go
@@ -49,15 +49,15 @@ func (n matchesNode) String() string {
 }
 
 func (n propertyNode) String() string {
-	switch n.property.(type) {
-	case identifierNode:
-		return fmt.Sprintf("%v.%v", n.node, n.property)
-	}
-	return fmt.Sprintf("%v[%v]", n.node, n.property)
+	return fmt.Sprintf("%v.%v", n.node, n.property)
+}
+
+func (n indexNode) String() string {
+	return fmt.Sprintf("%v[%v]", n.node, n.index)
 }
 
 func (n methodNode) String() string {
-	s := fmt.Sprintf("%v.%v(", n.node, n.property)
+	s := fmt.Sprintf("%v.%v(", n.node, n.method)
 	for i, a := range n.arguments {
 		if i != 0 {
 			s += ", "

--- a/print_test.go
+++ b/print_test.go
@@ -12,11 +12,11 @@ type printTest struct {
 
 var printTests = []printTest{
 	{
-		methodNode{nameNode{"foo"}, identifierNode{"bar"}, []Node{textNode{"arg1"}, numberNode{2}, boolNode{true}}},
+		methodNode{nameNode{"foo"}, "bar", []Node{textNode{"arg1"}, numberNode{2}, boolNode{true}}},
 		`foo.bar("arg1", 2, true)`,
 	},
 	{
-		propertyNode{propertyNode{methodNode{methodNode{nameNode{"foo"}, identifierNode{"bar"}, []Node{}}, identifierNode{"foo"}, []Node{}}, identifierNode{"baz"}}, numberNode{33}},
+		indexNode{propertyNode{methodNode{methodNode{nameNode{"foo"}, "bar", []Node{}}, "foo", []Node{}}, "baz"}, numberNode{33}},
 		"foo.bar().foo().baz[33]",
 	},
 	{
@@ -24,7 +24,7 @@ var printTests = []printTest{
 		`{"foo": 1, (1 + 2): 2}`,
 	},
 	{
-		functionNode{"call", []Node{propertyNode{arrayNode{[]Node{numberNode{1}, unaryNode{"not", boolNode{true}}}}, identifierNode{"foo"}}}},
+		functionNode{"call", []Node{propertyNode{arrayNode{[]Node{numberNode{1}, unaryNode{"not", boolNode{true}}}}, "foo"}}},
 		"call([1, not true].foo)",
 	},
 	{

--- a/type.go
+++ b/type.go
@@ -1,0 +1,316 @@
+package expr
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Type is a reflect.Type alias.
+type Type = reflect.Type
+
+type typesTable map[string]Type
+
+var (
+	boolType      = reflect.TypeOf(true)
+	numberType    = reflect.TypeOf(float64(0))
+	textType      = reflect.TypeOf("")
+	arrayType     = reflect.TypeOf([]interface{}{})
+	mapType       = reflect.TypeOf(map[interface{}]interface{}{})
+	interfaceType = reflect.TypeOf(new(interface{})).Elem()
+)
+
+func (n nilNode) Type(table typesTable) (Type, error) {
+	return nil, nil
+}
+
+func (n identifierNode) Type(table typesTable) (Type, error) {
+	return textType, nil
+}
+
+func (n numberNode) Type(table typesTable) (Type, error) {
+	return numberType, nil
+}
+
+func (n boolNode) Type(table typesTable) (Type, error) {
+	return boolType, nil
+}
+
+func (n textNode) Type(table typesTable) (Type, error) {
+	return textType, nil
+}
+
+func (n nameNode) Type(table typesTable) (Type, error) {
+	if t, ok := table[n.name]; ok {
+		return t, nil
+	}
+	return nil, fmt.Errorf("unknown name %v", n)
+}
+
+func (n unaryNode) Type(table typesTable) (Type, error) {
+	ntype, err := n.node.Type(table)
+	if err != nil {
+		return nil, err
+	}
+
+	switch n.operator {
+	case "!", "not":
+		if isBoolType(ntype) {
+			return boolType, nil
+		}
+		return nil, fmt.Errorf(`invalid operation: %v (mismatched type %v)`, n, ntype)
+	}
+
+	return interfaceType, nil
+}
+
+func (n binaryNode) Type(table typesTable) (Type, error) {
+	var err error
+	ltype, err := n.left.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	rtype, err := n.right.Type(table)
+	if err != nil {
+		return nil, err
+	}
+
+	switch n.operator {
+	case "==", "!=":
+		if isComparable(ltype, rtype) {
+			return boolType, nil
+		}
+		return nil, fmt.Errorf(`invalid operation: %v (mismatched types %v and %v)`, n, ltype, rtype)
+	case "or", "||", "and", "&&":
+		if isBoolType(ltype) && isBoolType(rtype) {
+			return boolType, nil
+		}
+		return nil, fmt.Errorf(`invalid operation: %v (mismatched types %v and %v)`, n, ltype, rtype)
+	}
+
+	return interfaceType, nil
+}
+
+func (n matchesNode) Type(table typesTable) (Type, error) {
+	return boolType, nil
+}
+
+func (n propertyNode) Type(table typesTable) (Type, error) {
+	ntype, err := n.node.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	if t, ok := fieldType(ntype, n.property); ok {
+		return t, nil
+	}
+	return nil, fmt.Errorf("%v undefined (type %v has no field %v)", n, ntype, n.property)
+}
+
+func (n indexNode) Type(table typesTable) (Type, error) {
+	ntype, err := n.node.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	_, err = n.index.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	if t, ok := indexType(ntype); ok {
+		return t, nil
+	}
+	return nil, fmt.Errorf("invalid operation: %v (type %v does not support indexing)", n, ntype)
+}
+
+func (n methodNode) Type(table typesTable) (Type, error) {
+	ntype, err := n.node.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range n.arguments {
+		_, err := node.Type(table)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if t, ok := fieldType(ntype, n.method); ok {
+		if f, ok := funcType(t); ok {
+			return f, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%v undefined (type %v has no method %v)", n, ntype, n.method)
+}
+
+func (n builtinNode) Type(table typesTable) (Type, error) {
+	if _, ok := builtins[n.name]; ok {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("%v undefined", n)
+}
+
+func (n functionNode) Type(table typesTable) (Type, error) {
+	for _, node := range n.arguments {
+		_, err := node.Type(table)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if t, ok := table[n.name]; ok {
+		if f, ok := funcType(t); ok {
+			return f, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown func %v", n)
+}
+
+func (n conditionalNode) Type(table typesTable) (Type, error) {
+	ctype, err := n.cond.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	if !isBoolType(ctype) {
+		return nil, fmt.Errorf("non-bool %v (type %v) used as condition", n.cond, ctype)
+	}
+	_, err = n.exp1.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	_, err = n.exp2.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	return boolType, nil
+}
+
+func (n arrayNode) Type(table typesTable) (Type, error) {
+	for _, node := range n.nodes {
+		_, err := node.Type(table)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return arrayType, nil
+}
+
+func (n mapNode) Type(table typesTable) (Type, error) {
+	for _, node := range n.pairs {
+		_, err := node.Type(table)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return mapType, nil
+}
+
+func (n pairNode) Type(table typesTable) (Type, error) {
+	var err error
+	_, err = n.key.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	_, err = n.value.Type(table)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// helper funcs for reflect
+
+func isComparable(ltype Type, rtype Type) bool {
+	ltype = dereference(ltype)
+	if ltype == nil {
+		return true
+	}
+	rtype = dereference(rtype)
+	if rtype == nil {
+		return true
+	}
+
+	if canBeNumberType(ltype) && canBeNumberType(rtype) {
+		return true
+	} else if ltype.Kind() == reflect.Interface {
+		return true
+	} else if rtype.Kind() == reflect.Interface {
+		return true
+	} else if ltype == rtype {
+		return true
+	}
+	return false
+}
+
+func isBoolType(ntype Type) bool {
+	ntype = dereference(ntype)
+	if ntype == nil {
+		return false
+	}
+
+	switch ntype.Kind() {
+	case reflect.Interface:
+		return true
+	case reflect.Bool:
+		return true
+	}
+	return false
+}
+
+func fieldType(ntype Type, name string) (Type, bool) {
+	ntype = dereference(ntype)
+	if ntype == nil {
+		return nil, false
+	}
+
+	switch ntype.Kind() {
+	case reflect.Interface:
+		return interfaceType, true
+	case reflect.Struct:
+		if t, ok := ntype.FieldByName(name); ok {
+			return t.Type, true
+		}
+	case reflect.Map:
+		return ntype.Elem(), true
+	}
+
+	return nil, false
+}
+
+func indexType(ntype Type) (Type, bool) {
+	ntype = dereference(ntype)
+	if ntype == nil {
+		return nil, false
+	}
+
+	switch ntype.Kind() {
+	case reflect.Interface:
+		return interfaceType, true
+	case reflect.Map, reflect.Array, reflect.Slice:
+		return ntype.Elem(), true
+	}
+
+	return nil, false
+}
+
+func funcType(ntype Type) (Type, bool) {
+	ntype = dereference(ntype)
+	if ntype == nil {
+		return nil, false
+	}
+
+	switch ntype.Kind() {
+	case reflect.Interface:
+		return interfaceType, true
+	case reflect.Func:
+		return ntype, true
+	}
+
+	return nil, false
+}
+
+func dereference(ntype Type) Type {
+	if ntype == nil {
+		return nil
+	}
+	if ntype.Kind() == reflect.Ptr {
+		ntype = dereference(ntype.Elem())
+	}
+	return ntype
+}

--- a/type_test.go
+++ b/type_test.go
@@ -1,0 +1,220 @@
+package expr_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/antonmedv/expr"
+)
+
+type typeTest string
+
+type typeErrorTest struct {
+	input string
+	err   string
+}
+
+var typeTests = []typeTest{
+	"Foo.Bar.Baz",
+	"Arr[0].Bar.Baz",
+	"Map['string'].Bar.Baz",
+	"Map.id.Bar.Baz",
+	"Any.Thing.Is.Ok",
+	"Irr['string'].next.goes['any thing']",
+	"Fn(Any)",
+	"Foo.Fn()",
+	"true ? Any : Any",
+	"len([])",
+	"true == false",
+	"nil",
+	"!Ok",
+	"[1,2,3]",
+	"{id: Foo.Bar.Baz, (1+1): Ok}",
+	"Abc()",
+	"Foo.Abc()",
+	"'a' == 'b' ~ 'c'",
+	"Num == 1",
+	"Int == Num",
+	"Num == Abc",
+	"Abc == Num",
+	"1 == 2 and true or Ok",
+	"IntPtr == Int",
+	"!OkPtr == Ok",
+	"1 == NumPtr",
+	"Foo.Bar == Map.id.Bar",
+	"StrPtr == nil",
+	"nil == nil",
+	"nil == IntPtr",
+	"Foo2p.Bar.Baz",
+}
+
+var typeErrorTests = []typeErrorTest{
+	{
+		"Foo.Bar.Not",
+		"Foo.Bar.Not undefined (type expr_test.bar has no field Not)",
+	},
+	{
+		"Noo",
+		"unknown name Noo",
+	},
+	{
+		"Noo()",
+		"unknown func Noo()",
+	},
+	{
+		"Foo()",
+		"unknown func Foo()",
+	},
+	{
+		"Foo['string']",
+		`invalid operation: Foo["string"] (type *expr_test.foo does not support indexing)`,
+	},
+	{
+		"Foo.Fn(Not)",
+		"unknown name Not",
+	},
+	{
+		"Foo.Bar()",
+		"Foo.Bar() undefined (type *expr_test.foo has no method Bar)",
+	},
+	{
+		"Foo.Bar.Not()",
+		"Foo.Bar.Not() undefined (type expr_test.bar has no method Not)",
+	},
+	{
+		"Arr[0].Not",
+		"Arr[0].Not undefined (type *expr_test.foo has no field Not)",
+	},
+	{
+		"Arr[Not]",
+		"unknown name Not",
+	},
+	{
+		"Not[0]",
+		"unknown name Not",
+	},
+	{
+		"Not.Bar",
+		"unknown name Not",
+	},
+	{
+		"Arr.Not",
+		"Arr.Not undefined (type []*expr_test.foo has no field Not)",
+	},
+	{
+		"Fn(Not)",
+		"unknown name Not",
+	},
+	{
+		"Map['str'].Not",
+		`Map["str"].Not undefined (type *expr_test.foo has no field Not)`,
+	},
+	{
+		"No ? Any.Ok : Any.Not",
+		"unknown name No",
+	},
+	{
+		"Any.Cond ? No : Any.Not",
+		"unknown name No",
+	},
+	{
+		"Any.Cond ? Any.Ok : No",
+		"unknown name No",
+	},
+	{
+		"Any ? Any : Any",
+		"non-bool Any (type map[string]interface {}) used as condition",
+	},
+	{
+		"!Not",
+		"unknown name Not",
+	},
+	{
+		"Not == Any",
+		"unknown name Not",
+	},
+	{
+		"[Not]",
+		"unknown name Not",
+	},
+	{
+		"{id: Not}",
+		"unknown name Not",
+	},
+	{
+		"{(Not): Any}",
+		"unknown name Not",
+	},
+	{
+		"(nil).Foo",
+		"nil.Foo undefined (type <nil> has no field Foo)",
+	},
+	{
+		"(nil)['Foo']",
+		`invalid operation: nil["Foo"] (type <nil> does not support indexing)`,
+	},
+	{
+		"1 and false",
+		"invalid operation: (1 and false) (mismatched types float64 and bool)",
+	},
+	{
+		"true or 0",
+		"invalid operation: (true or 0) (mismatched types bool and float64)",
+	},
+	{
+		"not IntPtr",
+		"invalid operation: not IntPtr (mismatched type *int)",
+	},
+}
+
+type abc interface {
+	Abc()
+}
+type bar struct {
+	Baz string
+}
+type foo struct {
+	Bar bar
+	Fn  func()
+	Abc abc
+}
+type payload struct {
+	Abc    abc
+	Foo    *foo
+	Arr    []*foo
+	Irr    []interface{}
+	Map    map[string]*foo
+	Any    map[string]interface{}
+	Fn     func()
+	Ok     bool
+	Num    float64
+	Int    int
+	Str    string
+	OkPtr  *bool
+	NumPtr *float64
+	IntPtr *int
+	StrPtr *string
+	Foo2p  **foo
+}
+
+func TestType(t *testing.T) {
+	for _, test := range typeTests {
+		_, err := expr.Parse(string(test), expr.With(&payload{}))
+		if err != nil {
+			t.Errorf("%s:\n\t%+v", test, err.Error())
+		}
+	}
+}
+
+func TestType_error(t *testing.T) {
+	for _, test := range typeErrorTests {
+		_, err := expr.Parse(test.input, expr.With(&payload{}))
+		if err == nil {
+			err = fmt.Errorf("<nil>")
+		}
+		if !strings.HasPrefix(err.Error(), test.err) || test.err == "" {
+			t.Errorf("%s:\ngot\n\t%+v\nexpected\n\t%v", test.input, err.Error(), test.err)
+		}
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -55,7 +55,14 @@ func cast(v interface{}) (float64, error) {
 
 func canBeNumber(v interface{}) bool {
 	if v != nil {
-		switch reflect.TypeOf(v).Kind() {
+		return canBeNumberType(reflect.TypeOf(v))
+	}
+	return false
+}
+
+func canBeNumberType(t Type) bool {
+	if t != nil {
+		switch t.Kind() {
 		case reflect.Float32, reflect.Float64:
 			fallthrough
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:


### PR DESCRIPTION
This commits implements more advance type checks in strict mode.
To enter strict mode set variable types with expr.Define() or
expr.With() functions.