### PR TITLE
Add support for method of map.

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -21,6 +21,22 @@ type evalErrorTest struct {
 	err   string
 }
 
+type evalParams map[string]interface{}
+
+func (p evalParams) Max(a, b float64) float64 {
+	if a < b {
+		return b
+	}
+	return a
+}
+
+func (p evalParams) Min(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 var evalTests = []evalTest{
 	{
 		"foo",
@@ -338,6 +354,16 @@ var evalTests = []evalTest{
 		`foo("world")`,
 		map[string]interface{}{"foo": func(in string) string { return "hello " + in }},
 		"hello world",
+	},
+	{
+		"Max(a, b)",
+		evalParams{"a": 1.23, "b": 3.21},
+		3.21,
+	},
+	{
+		"Min(a, b)",
+		evalParams{"a": 1.23, "b": 3.21},
+		1.23,
 	},
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -83,7 +83,7 @@ func extract(val interface{}, i interface{}) (interface{}, bool) {
 	return nil, false
 }
 
-func getFunc(val interface{}, i interface{}) (interface{}, bool) {
+func getFunc(val interface{}, name string) (interface{}, bool) {
 	v := reflect.ValueOf(val)
 	d := v
 	if v.Kind() == reflect.Ptr {
@@ -92,20 +92,18 @@ func getFunc(val interface{}, i interface{}) (interface{}, bool) {
 
 	switch d.Kind() {
 	case reflect.Map:
-		value := d.MapIndex(reflect.ValueOf(i))
+		value := d.MapIndex(reflect.ValueOf(name))
 		if value.IsValid() && value.CanInterface() {
 			return value.Interface(), true
 		}
 		// A map may have method too.
 		if v.NumMethod() > 0 {
-			name := reflect.ValueOf(i).String()
 			method := v.MethodByName(name)
 			if method.IsValid() && method.CanInterface() {
 				return method.Interface(), true
 			}
 		}
 	case reflect.Struct:
-		name := reflect.ValueOf(i).String()
 		method := v.MethodByName(name)
 		if method.IsValid() && method.CanInterface() {
 			return method.Interface(), true

--- a/runtime.go
+++ b/runtime.go
@@ -96,6 +96,14 @@ func getFunc(val interface{}, i interface{}) (interface{}, bool) {
 		if value.IsValid() && value.CanInterface() {
 			return value.Interface(), true
 		}
+		// A map may have method too.
+		if v.NumMethod() > 0 {
+			name := reflect.ValueOf(i).String()
+			method := v.MethodByName(name)
+			if method.IsValid() && method.CanInterface() {
+				return method.Interface(), true
+			}
+		}
 	case reflect.Struct:
 		name := reflect.ValueOf(i).String()
 		method := v.MethodByName(name)


### PR DESCRIPTION
Hi, I find out that while calling `getFunc(...)`, when the kind of val is `Map`, will only assume the method is provide by k-v. But even a map can have it is own method, and it will help a lot. 
For example:

```go
type ExprParams map[string]interface{}

func (e ExprParams) Max(a, b float64) float64 {
	return math.Max(a, b)
}

type User struct{
    Age int
}

func demo(){
    expr.Eval("Max(Teacher.Age, Student.Age)",ExprParams{
		"Teacher":User{Age:28},
		"Student":Student{Age:8},
	})
}

```

In this cases, `ExprParams` can provide default method ( like `Max`) easily.

And the implement is very simple, I hope it can improve the lib.

Thanks a lot.

PS: another question
I find that the only to calling for `getFunc(val interface{}, i interface{})`, the param `i` is both `string`, why not just change the `getFunc(...)` to `getFunc(val interface{}, funcName string)` ? That will save the cost of `reflect.ValueOf(i).String()`


