### PR TITLE
fixed visitor usage example as it had compilation errors

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -201,8 +201,8 @@ type visitor struct {
 
 func (v *visitor) Enter(node *ast.Node) {}
 func (v *visitor) Exit(node *ast.Node) {
-	if v, ok := node.(*ast.IdentifierNode); ok {
-	    v.identifiers = append(v.identifiers, node.Value)
+	if n, ok := (*node).(*ast.IdentifierNode); ok {
+		v.identifiers = append(v.identifiers, n.Value)
 	}
 }
 


### PR DESCRIPTION
I noticed the example contained a few compilation errors, related to pointers and the name of the variable used in the typecasting. Just a quick PR to update the example 😄 