### PR TITLE
fix map[string]interface{} 

### DIFF
--- a/vm/helpers.go
+++ b/vm/helpers.go
@@ -335,11 +335,26 @@ func equal(a, b interface{}) interface{} {
 		return x == b.(string)
 	}
 	// Two nil values should be considered as equal.
-	if (a == nil || reflect.ValueOf(a).IsNil()) && (b == nil || reflect.ValueOf(b).IsNil()) {
+	if isNil(a) && isNil(b) {
 		return true
 	}
 	return reflect.DeepEqual(a, b)
 }
+
+func isNil(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	r := reflect.ValueOf(v)
+	switch r.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+		return r.IsNil()
+	default:
+		return false
+	}
+}
+
+
 
 func less(a, b interface{}) interface{} {
 	switch x := a.(type) {


### PR DESCRIPTION

```go
	boolVal := false
	if out, err = expr.Eval("f == false", map[string]interface{}{"f": boolVal}); err != nil {
		panic(err)
	}
	fmt.Println("out", out)

	var timeNil *time.Time
	if out, err = expr.Eval("t == nil", map[string]interface{}{"t": timeNil}); err != nil {
		panic(err)
	}
	fmt.Println("out", out)
```