### PR TITLE
fix map [string] interface{}  is nil

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -436,6 +436,16 @@ func TestExpr(t *testing.T) {
 			return ret
 		},
 		Inc: func(a int) int { return a + 1 },
+		Map: map[string]interface{}{
+			"Int":    0,
+			"Bool":   true,
+			"String": "string",
+			"Array":  []int{1, 2, 3, 4, 5},
+			"Nil":    nil,
+			"Ticket": &ticket{
+				Price: 100,
+			},
+		},
 	}
 
 	tests := []struct {
@@ -738,6 +748,18 @@ func TestExpr(t *testing.T) {
 			`Nil == nil && nil == Nil && nil == nil && Nil == Nil`,
 			true,
 		},
+		{
+			`false == nil || 1 == nil || -.5 == nil || true == nil || 5.5 == nil`,
+			false,
+		},
+		{
+			`Map.Nil == nil && Map.Bool == true && Map.Int == 0 && Map.Nil2 == nil && Map.String == "string"`,
+			true,
+		},
+		{
+			`Map.Bool == nil || Map.String == nil || Map.Int == nil || Map.Ticket == nil || Map.Array == nil`,
+			false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -787,6 +809,7 @@ type mockEnv struct {
 	BirthDay             time.Time
 	Now                  time.Time
 	Nil                  *time.Time
+	Map                  map[string]interface{}
 }
 
 func (e *mockEnv) GetInt() int {

--- a/vm/generate/main.go
+++ b/vm/generate/main.go
@@ -140,20 +140,6 @@ func main() {
 		echo(``)
 	}
 
-	// isNil func
-	echo(`func isNil(v interface{}) bool {`)
-	echo(`if v == nil {`)
-	echo(`return true`)
-	echo(`}`)
-	echo(`r := reflect.ValueOf(v)`)
-	echo(`switch r.Kind() {`)
-	echo(`case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:`)
-	echo(`return r.IsNil()`)
-	echo(`default:`)
-	echo(`return false`)
-	echo(`}`)
-	echo(`}`)
-
 	b, err := format.Source([]byte(data))
 	check(err)
 	err = ioutil.WriteFile("helpers.go", b, 0644)

--- a/vm/generate/main.go
+++ b/vm/generate/main.go
@@ -123,12 +123,15 @@ func main() {
 		}
 		if helper.string {
 			echo(`case string:`)
-			echo(`return x %v b.(string)`, op)
+			echo(`switch y := b.(type) {`)
+			echo(`case %v:`, "string")
+			echo(`return x %v y`, op)
+			echo(`}`)
 		}
 		echo(`}`)
 		if name == "equal" {
 			echo(`// Two nil values should be considered as equal.`)
-			echo(`if (a == nil || reflect.ValueOf(a).IsNil()) && (b == nil || reflect.ValueOf(b).IsNil()) { return true }`)
+			echo(`if isNil(a) && isNil(b) { return true }`)
 			echo(`return reflect.DeepEqual(a, b)`)
 		} else {
 			echo(`panic(fmt.Sprintf("invalid operation: %%T %%v %%T", a, "%v", b))`, op)
@@ -136,6 +139,20 @@ func main() {
 		echo(`}`)
 		echo(``)
 	}
+
+	// isNil func
+	echo(`func isNil(v interface{}) bool {`)
+	echo(`if v == nil {`)
+	echo(`return true`)
+	echo(`}`)
+	echo(`r := reflect.ValueOf(v)`)
+	echo(`switch r.Kind() {`)
+	echo(`case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:`)
+	echo(`return r.IsNil()`)
+	echo(`default:`)
+	echo(`return false`)
+	echo(`}`)
+	echo(`}`)
 
 	b, err := format.Source([]byte(data))
 	check(err)

--- a/vm/helpers.go
+++ b/vm/helpers.go
@@ -344,19 +344,6 @@ func equal(a, b interface{}) interface{} {
 	return reflect.DeepEqual(a, b)
 }
 
-func isNil(v interface{}) bool {
-	if v == nil {
-		return true
-	}
-	r := reflect.ValueOf(v)
-	switch r.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
-		return r.IsNil()
-	default:
-		return false
-	}
-}
-
 func less(a, b interface{}) interface{} {
 	switch x := a.(type) {
 	case uint:
@@ -684,7 +671,10 @@ func less(a, b interface{}) interface{} {
 			return x < y
 		}
 	case string:
-		return x < b.(string)
+		switch y := b.(type) {
+		case string:
+			return x < y
+		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "<", b))
 }
@@ -1016,7 +1006,10 @@ func more(a, b interface{}) interface{} {
 			return x > y
 		}
 	case string:
-		return x > b.(string)
+		switch y := b.(type) {
+		case string:
+			return x > y
+		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, ">", b))
 }
@@ -1348,7 +1341,10 @@ func lessOrEqual(a, b interface{}) interface{} {
 			return x <= y
 		}
 	case string:
-		return x <= b.(string)
+		switch y := b.(type) {
+		case string:
+			return x <= y
+		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "<=", b))
 }
@@ -1680,7 +1676,10 @@ func moreOrEqual(a, b interface{}) interface{} {
 			return x >= y
 		}
 	case string:
-		return x >= b.(string)
+		switch y := b.(type) {
+		case string:
+			return x >= y
+		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, ">=", b))
 }
@@ -2012,7 +2011,10 @@ func add(a, b interface{}) interface{} {
 			return x + y
 		}
 	case string:
-		return x + b.(string)
+		switch y := b.(type) {
+		case string:
+			return x + y
+		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "+", b))
 }
@@ -3241,4 +3243,17 @@ func modulo(a, b interface{}) interface{} {
 		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "%", b))
+}
+
+func isNil(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	r := reflect.ValueOf(v)
+	switch r.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+		return r.IsNil()
+	default:
+		return false
+	}
 }

--- a/vm/helpers.go
+++ b/vm/helpers.go
@@ -3244,16 +3244,3 @@ func modulo(a, b interface{}) interface{} {
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "%", b))
 }
-
-func isNil(v interface{}) bool {
-	if v == nil {
-		return true
-	}
-	r := reflect.ValueOf(v)
-	switch r.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
-		return r.IsNil()
-	default:
-		return false
-	}
-}

--- a/vm/helpers.go
+++ b/vm/helpers.go
@@ -332,13 +332,29 @@ func equal(a, b interface{}) interface{} {
 			return x == y
 		}
 	case string:
-		return x == b.(string)
+		switch y := b.(type) {
+		case string:
+			return x == y
+		}
 	}
 	// Two nil values should be considered as equal.
-	if (a == nil || reflect.ValueOf(a).IsNil()) && (b == nil || reflect.ValueOf(b).IsNil()) {
+	if isNil(a) && isNil(b) {
 		return true
 	}
 	return reflect.DeepEqual(a, b)
+}
+
+func isNil(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	r := reflect.ValueOf(v)
+	switch r.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+		return r.IsNil()
+	default:
+		return false
+	}
 }
 
 func less(a, b interface{}) interface{} {

--- a/vm/runtime.go
+++ b/vm/runtime.go
@@ -313,3 +313,16 @@ func toFloat64(a interface{}) float64 {
 		panic(fmt.Sprintf("invalid operation: float64(%T)", x))
 	}
 }
+
+func isNil(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	r := reflect.ValueOf(v)
+	switch r.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+		return r.IsNil()
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
```go
	boolVal := false
	if out, err = expr.Eval("f != nil", map[string]interface{}{"f": boolVal}); err != nil {
		panic(err)
	}
	fmt.Println("out", out)


	trueVal := false
	if out, err = expr.Eval("f == true", map[string]interface{}{"f": trueVal}); err != nil {
		panic(err)
	}
	fmt.Println("out", out)


	stringVal := "string"
	if out, err = expr.Eval(`s == "string"`, map[string]interface{}{"s": stringVal}); err != nil {
		panic(err)
	}
	fmt.Println("out", out)


	var timeNil *time.Time
	if out, err = expr.Eval("t == nil", map[string]interface{}{"t": timeNil}); err != nil {
		panic(err)
	}
	fmt.Println("out", out)
```