### PR TITLE
runtime: Don't value copy structs from pointers on property access

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -97,3 +97,25 @@ func Benchmark_call(b *testing.B) {
 		b.Fatal(err)
 	}
 }
+
+func Benchmark_largeStructAccess(b *testing.B) {
+	type Env struct {
+		Data [1024*1024*10]byte
+		Field int
+	}
+
+	program, err := expr.Compile(`Field > 0 && Field > 1 && Field < 20`, expr.Env(Env{}))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	env := Env{Field: 21}
+
+	for n := 0; n < b.N; n++ {
+		_, err = vm.Run(program, &env)
+	}
+
+	if err != nil {
+		b.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adds a test with a 10mb struct passed by a pointer, it would be previously
copied on property accessed whereas now the accesses just go through the
pointer without a copy.

Previous:
Benchmark_largeStructAccess-4          200     7914350 ns/op

After:
Benchmark_largeStructAccess-4      2000000         912 ns/op