### PR TITLE
vm: Use a preallocated fixed call frame for typical argument sizes

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -197,3 +197,48 @@ func Benchmark_Calls(b *testing.B) {
 		b.Fatal(err)
 	}
 }
+
+func Benchmark_NewVMs(b *testing.B) {
+	type Env struct {
+		Field int
+	}
+
+	program, err := expr.Compile(`Field > 0`, expr.Env(Env{}))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	env := Env{}
+
+	for n := 0; n < b.N; n++ {
+		_, err = vm.Run(program, &env)
+	}
+
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func Benchmark_ReuseVMs(b *testing.B) {
+	type Env struct {
+		Field int
+	}
+
+	program, err := expr.Compile(`Field > 0`, expr.Env(Env{}))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	env := Env{}
+
+	v := vm.NewVM(false)
+
+	for n := 0; n < b.N; n++ {
+		v.Reset()
+		_, err = v.RunSafe(program, &env)
+	}
+
+	if err != nil {
+		b.Fatal(err)
+	}
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -165,3 +165,35 @@ func Benchmark_largeNestedArrayAccess(b *testing.B) {
 		b.Fatal(err)
 	}
 }
+
+func Benchmark_Calls(b *testing.B) {
+	type Env struct {
+		Field int
+		PassThrough func(int) int
+	}
+
+	code := ""
+
+	for i := 0; i < 50; i++ {
+		if i != 0 {
+			code += " && "
+		}
+		code += "PassThrough(10) > 5"
+	}
+
+	program, err := expr.Compile(code, expr.Env(Env{}))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	env := Env{}
+	env.PassThrough = func (i int) int { return i }
+
+	for n := 0; n < b.N; n++ {
+		_, err = vm.Run(program, &env)
+	}
+
+	if err != nil {
+		b.Fatal(err)
+	}
+}


### PR DESCRIPTION
For calls with 20 or less arguments use a preallocated fixed array
for the calling frame, otherwise fall back to heap allocation. This
avoids what was previously always a heap allocation at callsites.

Before:
Benchmark_Calls-4        50000       27618 ns/op

After:
Benchmark_Calls-4        50000       25948 ns/op