### PR TITLE
vm: Add basic support for VM instances to be reused (via Reset())

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -165,3 +165,48 @@ func Benchmark_largeNestedArrayAccess(b *testing.B) {
 		b.Fatal(err)
 	}
 }
+
+func Benchmark_NewVMs(b *testing.B) {
+	type Env struct {
+		Field int
+	}
+
+	program, err := expr.Compile(`Field > 0`, expr.Env(Env{}))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	env := Env{}
+
+	for n := 0; n < b.N; n++ {
+		_, err = vm.Run(program, &env)
+	}
+
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func Benchmark_ReuseVMs(b *testing.B) {
+	type Env struct {
+		Field int
+	}
+
+	program, err := expr.Compile(`Field > 0`, expr.Env(Env{}))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	env := Env{}
+
+	v := vm.NewVM(false)
+
+	for n := 0; n < b.N; n++ {
+		v.Reset()
+		_, err = v.RunSafe(program, &env)
+	}
+
+	if err != nil {
+		b.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adds a bench mark that shows this something around a 30% difference.

Benchmark_NewVMs-4       3000000         431 ns/op
Benchmark_ReuseVMs-4     5000000         302 ns/op