### PR TITLE
vm: Add a zerocopy mode for avoiding value copies.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -137,7 +137,9 @@ func Benchmark_largeNestedStructAccess(b *testing.B) {
 	env.Inner.Field = 21
 
 	for n := 0; n < b.N; n++ {
-		_, err = vm.Run(program, &env)
+		v := vm.NewVM(false)
+		v.SetZeroCopy(true)
+		_ = v.Run(program, &env)
 	}
 
 	if err != nil {
@@ -158,7 +160,9 @@ func Benchmark_largeNestedArrayAccess(b *testing.B) {
 	env := Env{}
 
 	for n := 0; n < b.N; n++ {
-		_, err = vm.Run(program, &env)
+		v := vm.NewVM(false)
+		v.SetZeroCopy(true)
+		_ = v.Run(program, &env)
 	}
 
 	if err != nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -36,6 +36,7 @@ type VM struct {
 	debug     bool
 	step      chan struct{}
 	curr      chan int
+	zerocopy  bool
 }
 
 func NewVM(debug bool) *VM {
@@ -79,7 +80,7 @@ func (vm *VM) Run(program *Program, env interface{}) interface{} {
 			vm.push(a)
 
 		case OpFetch:
-			vm.push(fetch(env, vm.constants[vm.arg()]))
+			vm.push(fetch(env, vm.constants[vm.arg()], vm.zerocopy))
 
 		case OpFetchMap:
 			vm.push(env.(map[string]interface{})[vm.constants[vm.arg()].(string)])
@@ -229,7 +230,7 @@ func (vm *VM) Run(program *Program, env interface{}) interface{} {
 		case OpIndex:
 			b := vm.pop()
 			a := vm.pop()
-			vm.push(fetch(a, b))
+			vm.push(fetch(a, b, vm.zerocopy))
 
 		case OpSlice:
 			from := vm.pop()
@@ -240,7 +241,7 @@ func (vm *VM) Run(program *Program, env interface{}) interface{} {
 		case OpProperty:
 			a := vm.pop()
 			b := vm.constants[vm.arg()]
-			vm.push(fetch(a, b))
+			vm.push(fetch(a, b, vm.zerocopy))
 
 		case OpCall:
 			call := vm.constants[vm.arg()].(Call)
@@ -381,4 +382,9 @@ func (vm *VM) Step() {
 
 func (vm *VM) Position() chan int {
 	return vm.curr
+}
+
+func (vm *VM) SetZeroCopy(a bool) bool {
+	vm.zerocopy = a
+	return a
 }


### PR DESCRIPTION
This is not backwards compatible, since arguments to functions can change from
having been a type to a *type now, and there isn't an easy way to track and fix
that up.  However, callers can opt-in to that behaviour with SetZeroCopy().