### PR TITLE
fix debugging channels

### DIFF
--- a/cmd/exe/debugger.go
+++ b/cmd/exe/debugger.go
@@ -147,6 +147,16 @@ func debugger() {
 	autostep := false
 	var breakpoint int
 
+	step := func() {
+		t := time.NewTimer(time.Second * 2)
+		defer t.Stop()
+
+		select {
+		case vm.Step() <- struct{}{}:
+		case <-t.C:
+		}
+	}
+
 	draw(0)
 	go func() {
 		for ip := range vm.Position() {
@@ -155,7 +165,7 @@ func debugger() {
 			if autostep {
 				if breakpoint != ip {
 					time.Sleep(20 * time.Millisecond)
-					vm.Step()
+					step()
 				} else {
 					autostep = false
 				}
@@ -174,7 +184,7 @@ func debugger() {
 				breakpoint = getSelectedPosition()
 				autostep = true
 			}
-			vm.Step()
+			step()
 		}
 		return event
 	})

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -44,8 +44,8 @@ func NewVM(debug bool) *VM {
 		debug: debug,
 	}
 	if vm.debug {
-		vm.step = make(chan struct{}, 0)
-		vm.curr = make(chan int, 0)
+		vm.step = make(chan struct{})
+		vm.curr = make(chan int)
 	}
 	return vm
 }
@@ -330,11 +330,6 @@ func (vm *VM) Run(program *Program, env interface{}) interface{} {
 		}
 	}
 
-	if vm.debug {
-		close(vm.curr)
-		close(vm.step)
-	}
-
 	if len(vm.stack) > 0 {
 		return vm.pop()
 	}
@@ -373,12 +368,10 @@ func (vm *VM) Scope() Scope {
 	return nil
 }
 
-func (vm *VM) Step() {
-	if vm.ip < len(vm.bytecode) {
-		vm.step <- struct{}{}
-	}
+func (vm *VM) Step() chan<- struct{} {
+	return vm.step
 }
 
-func (vm *VM) Position() chan int {
+func (vm *VM) Position() <-chan int {
 	return vm.curr
 }


### PR DESCRIPTION
- Remove unnecessary "0" argument to make chan
- Do not close the debugging channels when the VM completes (for #59)
- Change VM.Step() to return a channel. This allows the step channel to be
  used from inside a select, so the operation can be aborted by the caller
- Change VM.Position() to return a read-only channel