### PR TITLE
Allow to reuse vm

### DIFF
--- a/cmd/exe/debugger.go
+++ b/cmd/exe/debugger.go
@@ -32,7 +32,7 @@ func debugger() {
 	program, err := compiler.Compile(tree, nil)
 	check(err)
 
-	vm := NewVM(true)
+	vm := Debug()
 
 	app := tview.NewApplication()
 	table := tview.NewTable()
@@ -54,7 +54,7 @@ func debugger() {
 	app.SetRoot(flex, true)
 
 	go func() {
-		out := vm.Run(program, nil)
+		out, _ := vm.Run(program, nil)
 		app.QueueUpdateDraw(func() {
 			sub.RemoveItem(scope)
 			result := tview.NewTextView()

--- a/docs/Optimizations.md
+++ b/docs/Optimizations.md
@@ -79,4 +79,41 @@ Will be replaced with result of `fib(42)` on compile step. No need to calculate 
 
 [ConstExpr Example](https://pkg.go.dev/github.com/antonmedv/expr?tab=doc#ConstExpr)
 
+## Reuse VM
+
+It is possible to reuse a virtual machine between re-runs on the program. 
+This adds a small increase in performance (from 4% to 40% depending on a program).
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/vm"
+)
+
+func main() {
+	env := map[string]interface{}{
+		"foo": 1,
+		"bar": 2,
+	}
+
+	program, err := expr.Compile("foo + bar", expr.Env(env))
+	if err != nil {
+		panic(err)
+	}
+
+	// Reuse this vm instance between runs
+	v := vm.VM{}
+
+	out, err := v.Run(program, env)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Print(out)
+}
+```
+
 * [Contents](README.md)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell v1.3.0 h1:r35w0JBADPZCVQijYebl6YMWWtHRqVEGt7kL2eBADRM=
 github.com/gdamore/tcell v1.3.0/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
@@ -11,6 +13,7 @@ github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.8 h1:3tS41NlGYSmhhe/8fhGRzc+z3AYCw1Fe1WAyLuujKs0=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498 h1:4CFNy7/q7P06AsIONZzuWy7jcdqEmYQvOZ9FAFZdbls=
 github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShEf0EaOCaTQYyB7d5nSbb181KtjlS+84=
@@ -26,7 +29,9 @@ golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
For fast path example +40% boost:
```
go test -run=xxx -bench=expr
goos: darwin
goarch: amd64
pkg: github.com/antonmedv/expr
Benchmark_expr-8            	 7132740	       164 ns/op
Benchmark_expr_reuse_vm-8   	12526617	        92.1 ns/op
PASS
ok  	github.com/antonmedv/expr	2.810s
```

For real-world example +4% boost:
```
go test -run=xxx -bench=realWorld
goos: darwin
goarch: amd64
pkg: github.com/antonmedv/expr
Benchmark_realWorld-8            	  486003	      2450 ns/op
Benchmark_realWorld_reuse_vm-8   	  470234	      2395 ns/op
Benchmark_realWorldInsane-8      	    1358	    871703 ns/op
PASS
ok  	github.com/antonmedv/expr	6.210s
```