### PR TITLE
Fix double dot range for invalid input

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -813,6 +813,14 @@ func TestExpr(t *testing.T) {
 			6,
 		},
 		{
+			`4 in 5..1`,
+			false,
+		},
+		{
+			`4..0`,
+			[]int{},
+		},
+		{
 			`MapArg({foo: "bar"})`,
 			"bar",
 		},

--- a/optimizer/const_range.go
+++ b/optimizer/const_range.go
@@ -14,6 +14,14 @@ func (*constRange) Exit(node *Node) {
 			if min, ok := n.Left.(*IntegerNode); ok {
 				if max, ok := n.Right.(*IntegerNode); ok {
 					size := max.Value - min.Value + 1
+					// In case the max < min, patch empty slice
+					// as max must be greater than equal to min.
+					if size < 1 {
+						Patch(node, &ConstantNode{
+							Value: make([]int, 0),
+						})
+						return
+					}
 					// In this case array is too big. Skip generation,
 					// and wait for memory budget detection on runtime.
 					if size > 1e6 {

--- a/vm/runtime.go
+++ b/vm/runtime.go
@@ -220,6 +220,9 @@ func exponent(a, b interface{}) float64 {
 
 func makeRange(min, max int) []int {
 	size := max - min + 1
+	if size <= 0 {
+		return []int{}
+	}
 	rng := make([]int, size)
 	for i := range rng {
 		rng[i] = min + i


### PR DESCRIPTION
For double dot range i.e., `a..b` where `a` and `b` are inclusive when ranging from `a` to `b`. Therefore every element x in the range must satisfy `a <= x && x <= b`

Previously, it used to panic because, for `a..b`, `a` is considered minimum and `b` is considered maximum which results in negative size when allocating memory for slice using `make`. Ref:

**file**: _optimizer/const_range.go_ 
```go
size := max.Value - min.Value + 1
...
...
value := make([]int, size)
``` 
So, for invalid inputs where a > b, it panics. Similar problem is there in `vm/runtime.go`'s `makeRange` function as well.

Changing it in the optimizer and makeRange seems apt to me, but I figured it could be handled in `checker/checker.go` and cry the error out loud that the expression is not correct, but it didn't feel right.

@antonmedv What do you think? Having an empty slice instead of exiting out with an error seems good, right?

Fixes #163