### PR TITLE
Fix handling of space(s) in between operator

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -629,6 +629,14 @@ func TestExpr(t *testing.T) {
 			true,
 		},
 		{
+			`Two not in 0..1`,
+			true,
+		},
+		{
+			`Two not    in 0..1`,
+			true,
+		},
+		{
 			`Int32 in [10, 20]`,
 			false,
 		},
@@ -1326,7 +1334,6 @@ func (p *stringerPatcher) Exit(node *ast.Node) {
 			Method: "String",
 		})
 	}
-
 }
 
 type lengthPatcher struct{}

--- a/parser/lexer/lexer.go
+++ b/parser/lexer/lexer.go
@@ -14,7 +14,7 @@ func Lex(source *file.Source) ([]Token, error) {
 		tokens: make([]Token, 0),
 	}
 
-	l.loc = file.Location{1, 0}
+	l.loc = file.Location{Line: 1, Column: 0}
 	l.prev = l.loc
 	l.startLoc = l.loc
 
@@ -31,10 +31,9 @@ func Lex(source *file.Source) ([]Token, error) {
 
 type lexer struct {
 	input      string
-	state      stateFn
 	tokens     []Token
 	start, end int           // current position in input
-	width      int           // last rune with
+	width      int           // last rune width
 	startLoc   file.Location // start location
 	prev, loc  file.Location // prev location of end location, end location
 	err        *file.Error
@@ -120,14 +119,17 @@ func (l *lexer) acceptRun(valid string) {
 }
 
 func (l *lexer) acceptWord(word string) bool {
-	pos := l.end
-	loc := l.loc
-	prev := l.prev
+	pos, loc, prev := l.end, l.loc, l.prev
+
+	// Skip spaces (U+0020) if any
+	r := l.peek()
+	for ; r == ' '; r = l.peek() {
+		l.next()
+	}
+
 	for _, ch := range word {
 		if l.next() != ch {
-			l.end = pos
-			l.loc = loc
-			l.prev = prev
+			l.end, l.loc, l.prev = pos, loc, prev
 			return false
 		}
 	}

--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -2,10 +2,11 @@ package lexer_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/antonmedv/expr/file"
 	. "github.com/antonmedv/expr/parser/lexer"
@@ -63,7 +64,7 @@ var lexTests = []lexTest{
 		},
 	},
 	{
-		`not in not abc not i not(false) not  in`,
+		`not in not abc not i not(false) not  in not   in`,
 		[]Token{
 			{Kind: Operator, Value: "not in"},
 			{Kind: Operator, Value: "not"},
@@ -74,8 +75,8 @@ var lexTests = []lexTest{
 			{Kind: Bracket, Value: "("},
 			{Kind: Identifier, Value: "false"},
 			{Kind: Bracket, Value: ")"},
-			{Kind: Operator, Value: "not"},
-			{Kind: Operator, Value: "in"},
+			{Kind: Operator, Value: "not in"},
+			{Kind: Operator, Value: "not in"},
 			{Kind: EOF},
 		},
 	},
@@ -162,7 +163,6 @@ func TestLex_error(t *testing.T) {
 	tests := strings.Split(strings.Trim(errorTests, "\n"), "\n\n")
 
 	for _, test := range tests {
-
 		input := strings.SplitN(test, "\n", 2)
 		if len(input) != 2 {
 			t.Errorf("syntax error in test: %q", test)

--- a/parser/lexer/state.go
+++ b/parser/lexer/state.go
@@ -125,10 +125,12 @@ loop:
 }
 
 func not(l *lexer) stateFn {
-	if l.acceptWord(" in") {
-		l.emit(Operator)
-	} else {
-		l.emit(Operator)
+	switch l.acceptWord("in") {
+	case true:
+		l.emitValue(Operator, "not in")
+	case false:
+		l.emitValue(Operator, "not")
 	}
+
 	return root
 }

--- a/parser/lexer/token.go
+++ b/parser/lexer/token.go
@@ -10,11 +10,11 @@ type Kind string
 
 const (
 	Identifier Kind = "Identifier"
-	Number          = "Number"
-	String          = "String"
-	Operator        = "Operator"
-	Bracket         = "Bracket"
-	EOF             = "EOF"
+	Number     Kind = "Number"
+	String     Kind = "String"
+	Operator   Kind = "Operator"
+	Bracket    Kind = "Bracket"
+	EOF        Kind = "EOF"
 )
 
 type Token struct {


### PR DESCRIPTION
Thir PR should fix the handling of extra space `(U+0020)` between multi-word operators (eg. `not in`). I had another hacky solution though where I initially thought to sanitize the input in `parser/parser.go` in the `Parse` function with something like:
```go
func sanitize(input string) string {
       return strings.Join(strings.Fields(strings.TrimSpace(input)), " ")
}
```
But again this is a bad idea.

Now the implementation is generic enough and should help to parse other multi-word operators as well. @antonmedv does it look good to you?

Also did some nit fixes:
- Remove the unused state from lexer struct
- Fix formatting
- Use the type Kind for Number, String, Operator, Bracket, EOF

Fixes #123 