### PR TITLE
Add nil safe operator

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -48,7 +48,8 @@ type NilNode struct {
 
 type IdentifierNode struct {
 	base
-	Value string
+	Value   string
+	NilSafe bool
 }
 
 type IntegerNode struct {
@@ -100,6 +101,7 @@ type PropertyNode struct {
 	base
 	Node     Node
 	Property string
+	NilSafe  bool
 }
 
 type IndexNode struct {
@@ -120,6 +122,7 @@ type MethodNode struct {
 	Node      Node
 	Method    string
 	Arguments []Node
+	NilSafe   bool
 }
 
 type FunctionNode struct {

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -136,7 +136,10 @@ func (v *visitor) IdentifierNode(node *ast.IdentifierNode) reflect.Type {
 		}
 		return interfaceType
 	}
-	return v.error(node, "unknown name %v", node.Value)
+	if !node.NilSafe {
+		return v.error(node, "unknown name %v", node.Value)
+	}
+	return nilType
 }
 
 func (v *visitor) IntegerNode(*ast.IntegerNode) reflect.Type {
@@ -276,12 +279,13 @@ func (v *visitor) MatchesNode(node *ast.MatchesNode) reflect.Type {
 
 func (v *visitor) PropertyNode(node *ast.PropertyNode) reflect.Type {
 	t := v.visit(node.Node)
-
 	if t, ok := fieldType(t, node.Property); ok {
 		return t
 	}
-
-	return v.error(node, "type %v has no field %v", t, node.Property)
+	if !node.NilSafe {
+		return v.error(node, "type %v has no field %v", t, node.Property)
+	}
+	return nil
 }
 
 func (v *visitor) IndexNode(node *ast.IndexNode) reflect.Type {
@@ -361,7 +365,10 @@ func (v *visitor) MethodNode(node *ast.MethodNode) reflect.Type {
 			return v.checkFunc(fn, method, node, node.Method, node.Arguments)
 		}
 	}
-	return v.error(node, "type %v has no method %v", t, node.Method)
+	if !node.NilSafe {
+		return v.error(node, "type %v has no method %v", t, node.Method)
+	}
+	return nil
 }
 
 // checkFunc checks func arguments and returns "return type" of func or method.

--- a/cmd/exe/dot.go
+++ b/cmd/exe/dot.go
@@ -87,7 +87,11 @@ func (v *visitor) Exit(ref *Node) {
 
 	case *PropertyNode:
 		a := v.pop()
-		v.push(fmt.Sprintf(".%v", node.Property))
+		if !node.NilSafe {
+			v.push(fmt.Sprintf(".%v", node.Property))
+		} else {
+			v.push(fmt.Sprintf("?.%v", node.Property))
+		}
 		v.link(a)
 
 	case *IndexNode:
@@ -103,7 +107,11 @@ func (v *visitor) Exit(ref *Node) {
 			args = append(args, v.pop())
 		}
 		a := v.pop()
-		v.push(fmt.Sprintf(".%v(...)", node.Method))
+		if !node.NilSafe {
+			v.push(fmt.Sprintf(".%v(...)", node.Method))
+		} else {
+			v.push(fmt.Sprintf("?.%v(...)", node.Method))
+		}
 		v.link(a)
 		for i := len(args) - 1; i >= 0; i-- {
 			v.link(args[i])

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -180,6 +180,8 @@ func (c *compiler) IdentifierNode(node *ast.IdentifierNode) {
 	v := c.makeConstant(node.Value)
 	if c.mapEnv {
 		c.emit(OpFetchMap, v...)
+	} else if node.NilSafe {
+		c.emit(OpFetchNilSafe, v...)
 	} else {
 		c.emit(OpFetch, v...)
 	}
@@ -401,7 +403,11 @@ func (c *compiler) MatchesNode(node *ast.MatchesNode) {
 
 func (c *compiler) PropertyNode(node *ast.PropertyNode) {
 	c.compile(node.Node)
-	c.emit(OpProperty, c.makeConstant(node.Property)...)
+	if !node.NilSafe {
+		c.emit(OpProperty, c.makeConstant(node.Property)...)
+	} else {
+		c.emit(OpPropertyNilSafe, c.makeConstant(node.Property)...)
+	}
 }
 
 func (c *compiler) IndexNode(node *ast.IndexNode) {
@@ -430,7 +436,11 @@ func (c *compiler) MethodNode(node *ast.MethodNode) {
 	for _, arg := range node.Arguments {
 		c.compile(arg)
 	}
-	c.emit(OpMethod, c.makeConstant(Call{Name: node.Method, Size: len(node.Arguments)})...)
+	if !node.NilSafe {
+		c.emit(OpMethod, c.makeConstant(Call{Name: node.Method, Size: len(node.Arguments)})...)
+	} else {
+		c.emit(OpMethodNilSafe, c.makeConstant(Call{Name: node.Method, Size: len(node.Arguments)})...)
+	}
 }
 
 func (c *compiler) FunctionNode(node *ast.FunctionNode) {

--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -64,6 +64,23 @@ var lexTests = []lexTest{
 		},
 	},
 	{
+		"a and orb().val and foo?.bar",
+		[]Token{
+			{Kind: Identifier, Value: "a"},
+			{Kind: Operator, Value: "and"},
+			{Kind: Identifier, Value: "orb"},
+			{Kind: Bracket, Value: "("},
+			{Kind: Bracket, Value: ")"},
+			{Kind: Operator, Value: "."},
+			{Kind: Identifier, Value: "val"},
+			{Kind: Operator, Value: "and"},
+			{Kind: Identifier, Value: "foo"},
+			{Kind: Operator, Value: "?."},
+			{Kind: Identifier, Value: "bar"},
+			{Kind: EOF},
+		},
+	},
+	{
 		`not in not abc not i not(false) not  in not   in`,
 		[]Token{
 			{Kind: Operator, Value: "not in"},

--- a/parser/lexer/state.go
+++ b/parser/lexer/state.go
@@ -24,6 +24,11 @@ func root(l *lexer) stateFn {
 	case '0' <= r && r <= '9':
 		l.backup()
 		return number
+	case r == '?':
+		if l.peek() == '.' {
+			return nilsafe
+		}
+		l.emit(Operator)
 	case strings.ContainsRune("([{", r):
 		l.emit(Bracket)
 	case strings.ContainsRune(")]}", r):
@@ -98,6 +103,13 @@ func dot(l *lexer) stateFn {
 		return number
 	}
 	l.accept(".")
+	l.emit(Operator)
+	return root
+}
+
+func nilsafe(l *lexer) stateFn {
+	l.next()
+	l.accept("?.")
 	l.emit(Operator)
 	return root
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -99,6 +99,10 @@ func TestParse(t *testing.T) {
 			&ast.PropertyNode{Node: &ast.IdentifierNode{Value: "foo"}, Property: "bar"},
 		},
 		{
+			"foo?.bar",
+			&ast.PropertyNode{Node: &ast.IdentifierNode{Value: "foo", NilSafe: true}, Property: "bar", NilSafe: true},
+		},
+		{
 			"foo['all']",
 			&ast.IndexNode{Node: &ast.IdentifierNode{Value: "foo"}, Index: &ast.StringNode{Value: "all"}},
 		},

--- a/vm/opcodes.go
+++ b/vm/opcodes.go
@@ -5,6 +5,7 @@ const (
 	OpPop
 	OpRot
 	OpFetch
+	OpFetchNilSafe
 	OpFetchMap
 	OpTrue
 	OpFalse
@@ -38,9 +39,11 @@ const (
 	OpIndex
 	OpSlice
 	OpProperty
+	OpPropertyNilSafe
 	OpCall
 	OpCallFast
 	OpMethod
+	OpMethodNilSafe
 	OpArray
 	OpMap
 	OpLen

--- a/vm/program.go
+++ b/vm/program.go
@@ -73,6 +73,9 @@ func (program *Program) Disassemble() string {
 		case OpFetch:
 			constant("OpFetch")
 
+		case OpFetchNilSafe:
+			constant("OpFetchNilSafe")
+
 		case OpFetchMap:
 			constant("OpFetchMap")
 
@@ -172,6 +175,9 @@ func (program *Program) Disassemble() string {
 		case OpProperty:
 			constant("OpProperty")
 
+		case OpPropertyNilSafe:
+			constant("OpPropertyNilSafe")
+
 		case OpCall:
 			constant("OpCall")
 
@@ -180,6 +186,9 @@ func (program *Program) Disassemble() string {
 
 		case OpMethod:
 			constant("OpMethod")
+
+		case OpMethodNilSafe:
+			constant("OpMethodNilSafe")
 
 		case OpArray:
 			code("OpArray")

--- a/vm/runtime.go
+++ b/vm/runtime.go
@@ -15,7 +15,7 @@ type Call struct {
 
 type Scope map[string]interface{}
 
-func fetch(from interface{}, i interface{}) interface{} {
+func fetch(from, i interface{}, nilsafe bool) interface{} {
 	v := reflect.ValueOf(from)
 	kind := v.Kind()
 
@@ -51,8 +51,10 @@ func fetch(from interface{}, i interface{}) interface{} {
 			return value.Interface()
 		}
 	}
-
-	panic(fmt.Sprintf("cannot fetch %v from %T", i, from))
+	if !nilsafe {
+		panic(fmt.Sprintf("cannot fetch %v from %T", i, from))
+	}
+	return nil
 }
 
 func slice(array, from, to interface{}) interface{} {
@@ -116,6 +118,13 @@ func FetchFn(from interface{}, name string) reflect.Value {
 		}
 	}
 	panic(fmt.Sprintf(`cannot get "%v" from %T`, name, from))
+}
+
+func FetchFnNil(from interface{}, name string) reflect.Value {
+	if v := reflect.ValueOf(from); !v.IsValid() {
+		return v
+	}
+	return FetchFn(from, name)
 }
 
 func in(needle interface{}, array interface{}) bool {


### PR DESCRIPTION
Takes care of #147 

Only thing this doesn't work on is when the env struct is predefined before compiling due to `OpEqualString` and `OpEqualInt` optimizations doing type casts.

Not completely happy with the way it's implemented, but it was the easiest to do without changing much core code.