### PR TITLE
acceptWord checks the rune after word

### DIFF
--- a/parser/lexer/lexer.go
+++ b/parser/lexer/lexer.go
@@ -133,6 +133,11 @@ func (l *lexer) acceptWord(word string) bool {
 			return false
 		}
 	}
+	if r = l.peek(); r != ' ' && r != eof {
+		l.end, l.loc, l.prev = pos, loc, prev
+		return false
+	}
+
 	return true
 }
 

--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -98,6 +98,21 @@ var lexTests = []lexTest{
 		},
 	},
 	{
+		"not in_var",
+		[]Token{
+			{Kind: Operator, Value: "not"},
+			{Kind: Identifier, Value: "in_var"},
+			{Kind: EOF},
+		},
+	},
+	{
+		"not in",
+		[]Token{
+			{Kind: Operator, Value: "not in"},
+			{Kind: EOF},
+		},
+	},
+	{
 		`1..5`,
 		[]Token{
 			{Kind: Number, Value: "1"},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -65,9 +65,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			"(1 - 2) * 3",
-			&ast.BinaryNode{Operator: "*",
-				Left: &ast.BinaryNode{Operator: "-", Left: &ast.IntegerNode{Value: 1},
-					Right: &ast.IntegerNode{Value: 2}}, Right: &ast.IntegerNode{Value: 3},
+			&ast.BinaryNode{
+				Operator: "*",
+				Left: &ast.BinaryNode{
+					Operator: "-", Left: &ast.IntegerNode{Value: 1},
+					Right: &ast.IntegerNode{Value: 2},
+				}, Right: &ast.IntegerNode{Value: 3},
 			},
 		},
 		{
@@ -126,7 +129,8 @@ func TestParse(t *testing.T) {
 			"foo.bar().foo().baz[33]",
 			&ast.IndexNode{
 				Node: &ast.PropertyNode{Node: &ast.MethodNode{Node: &ast.MethodNode{
-					Node: &ast.IdentifierNode{Value: "foo"}, Method: "bar", Arguments: []ast.Node{}}, Method: "foo", Arguments: []ast.Node{}}, Property: "baz"},
+					Node: &ast.IdentifierNode{Value: "foo"}, Method: "bar", Arguments: []ast.Node{},
+				}, Method: "foo", Arguments: []ast.Node{}}, Property: "baz"},
 				Index: &ast.IntegerNode{Value: 33},
 			},
 		},
@@ -193,6 +197,10 @@ func TestParse(t *testing.T) {
 		{
 			"0 in []",
 			&ast.BinaryNode{Operator: "in", Left: &ast.IntegerNode{}, Right: &ast.ArrayNode{Nodes: []ast.Node{}}},
+		},
+		{
+			"not in_var",
+			&ast.UnaryNode{Operator: "not", Node: &ast.IdentifierNode{Value: "in_var"}},
 		},
 		{
 			"all(Tickets, {.Price > 0})",


### PR DESCRIPTION
`acceptWord` finds the substring `word`, but does not look at the following rune. As a result, `not in_var` is interpreted as Operator(`not in`) and Identifier(`_var`)