### PR TITLE
Add support for ConstantNode in checker

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -71,6 +71,8 @@ func (v *visitor) visit(node ast.Node) reflect.Type {
 		t = v.BoolNode(n)
 	case *ast.StringNode:
 		t = v.StringNode(n)
+	case *ast.ConstantNode:
+		t = v.ConstantNode(n)
 	case *ast.UnaryNode:
 		t = v.UnaryNode(n)
 	case *ast.BinaryNode:
@@ -158,6 +160,10 @@ func (v *visitor) BoolNode(*ast.BoolNode) reflect.Type {
 
 func (v *visitor) StringNode(*ast.StringNode) reflect.Type {
 	return stringType
+}
+
+func (v *visitor) ConstantNode(node *ast.ConstantNode) reflect.Type {
+	return reflect.TypeOf(node.Value)
 }
 
 func (v *visitor) UnaryNode(node *ast.UnaryNode) reflect.Type {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2,11 +2,14 @@ package checker_test
 
 import (
 	"fmt"
+	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/ast"
 	"github.com/antonmedv/expr/checker"
 	"github.com/antonmedv/expr/conf"
 	"github.com/antonmedv/expr/parser"
@@ -83,6 +86,19 @@ func TestVisitor_BuiltinNode(t *testing.T) {
 		_, err = checker.Check(tree, conf.New(&mockEnv{}))
 		assert.NoError(t, err)
 	}
+}
+
+func TestVisitor_ConstantNode(t *testing.T) {
+	tree, err := parser.Parse(`re("[a-z]")`)
+
+	regexValue := regexp.MustCompile("[a-z]")
+	constNode := &ast.ConstantNode{Value: regexValue}
+	ast.Patch(&tree.Node, constNode)
+
+	_, err = checker.Check(tree, conf.New(&mockEnv{}))
+	assert.NoError(t, err)
+
+	assert.Equal(t, reflect.TypeOf(regexValue), tree.Node.Type())
 }
 
 func TestCheck(t *testing.T) {


### PR DESCRIPTION
After implementing an ast.Visitor (and using expr.Patch) which replaced some nodes with a ConstantNode, I was getting panics from checker.Check, as it didn't expect a ConstantNode, but this simple patch fixes that.