### PR TITLE
docs: fix invalid return value in "Returning errors" example.

### DIFF
--- a/docs/Custom-Functions.md
+++ b/docs/Custom-Functions.md
@@ -154,7 +154,7 @@ func main() {
 			if i < 0 {
 				return 0, errors.New("value cannot be less than zero")
 			}
-			return i * 2
+			return i * 2, nil
 		},
 	}
 


### PR DESCRIPTION
As mentioned in https://github.com/antonmedv/expr/issues/198 example for "Returning errors" documentation had invalid return value.