### PR TITLE
Dont count newline character as a terminating string literal when parsing

### DIFF
--- a/parser/lexer/lexer.go
+++ b/parser/lexer/lexer.go
@@ -197,7 +197,7 @@ func (l *lexer) scanEscape(quote rune) rune {
 func (l *lexer) scanString(quote rune) (n int) {
 	ch := l.next() // read character after quote
 	for ch != quote {
-		if ch == '\n' || ch == eof {
+		if ch == eof {
 			l.error("literal not terminated")
 			return
 		}


### PR DESCRIPTION
## Request 

Don't count newline character '\n' as a terminating string literal when parsing. The newline character within a sentence may be intentional and meaningful for other purposes.

With current implementation that treats newline character as a terminating literal for parsing, the following program will panic:
```
package main

import (
	"fmt"

	"github.com/antonmedv/expr"
)

type Env struct {
}

func (Env) CountNewLine(s string) int {
	newlineCount := 0
	for ch := range s {
		if ch == '\n' {
			newlineCount++
		}
	}
	return newlineCount
}

func main() {
	code := "CountNewLine(\"Hello\nHello\")"
	program, err := expr.Compile(code, expr.Env(Env{}))
	if err != nil {
		panic(err)
	}

	env := Env{}
	output, err := expr.Run(program, env)
	if err != nil {
		panic(err)   <-- panic
	}

	fmt.Println(output)
}
```
