### PR TITLE
Adds support for common operators for time.Time

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -244,7 +244,7 @@ func (v *visitor) BinaryNode(node *ast.BinaryNode) reflect.Type {
 			return combined(l, r)
 		}
 		if isTime(l) && isTime(r) {
-			return boolType
+			return durationType
 		}
 
 	case "/", "*":
@@ -270,7 +270,10 @@ func (v *visitor) BinaryNode(node *ast.BinaryNode) reflect.Type {
 			return stringType
 		}
 		if isTime(l) && isDuration(r) {
-			return boolType
+			return timeType
+		}
+		if isDuration(l) && isTime(r) {
+			return timeType
 		}
 
 	case "contains", "startsWith", "endsWith":

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -208,6 +208,9 @@ func (v *visitor) BinaryNode(node *ast.BinaryNode) reflect.Type {
 		if isComparable(l, r) {
 			return boolType
 		}
+		if isTime(l) && isTime(r) {
+			return boolType
+		}
 
 	case "or", "||", "and", "&&":
 		if isBool(l) && isBool(r) {
@@ -232,8 +235,19 @@ func (v *visitor) BinaryNode(node *ast.BinaryNode) reflect.Type {
 		if isString(l) && isString(r) {
 			return boolType
 		}
+		if isTime(l) && isTime(r) {
+			return boolType
+		}
 
-	case "/", "-", "*":
+	case "-":
+		if isNumber(l) && isNumber(r) {
+			return combined(l, r)
+		}
+		if isTime(l) && isTime(r) {
+			return boolType
+		}
+
+	case "/", "*":
 		if isNumber(l) && isNumber(r) {
 			return combined(l, r)
 		}
@@ -254,6 +268,9 @@ func (v *visitor) BinaryNode(node *ast.BinaryNode) reflect.Type {
 		}
 		if isString(l) && isString(r) {
 			return stringType
+		}
+		if isTime(l) && isDuration(r) {
+			return boolType
 		}
 
 	case "contains", "startsWith", "endsWith":
@@ -348,9 +365,9 @@ func (v *visitor) FunctionNode(node *ast.FunctionNode) reflect.Type {
 				fn.NumIn() == inputParamsCount &&
 				((fn.NumOut() == 1 && // Function with one return value
 					fn.Out(0).Kind() == reflect.Interface) ||
-				(fn.NumOut() == 2 && // Function with one return value and an error
-					fn.Out(0).Kind() == reflect.Interface &&
-					fn.Out(1) == errorType)) {
+					(fn.NumOut() == 2 && // Function with one return value and an error
+						fn.Out(0).Kind() == reflect.Interface &&
+						fn.Out(1) == errorType)) {
 				rest := fn.In(fn.NumIn() - 1) // function has only one param for functions and two for methods
 				if rest.Kind() == reflect.Slice && rest.Elem().Kind() == reflect.Interface {
 					node.Fast = true

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -176,6 +176,31 @@ func TestCheck(t *testing.T) {
 		"count(1..30, {# % 3 == 0}) > 0",
 		"map(1..3, {#}) == [1,2,3]",
 		"map(filter(ArrayOfFoo, {.Int64 > 0}), {.Bar})",
+		"Any == Time",
+		"Any != Time",
+		"Any > Time",
+		"Any >= Time",
+		"Any < Time",
+		"Any <= Time",
+		"Any - Time",
+		"Any == Any",
+		"Any != Any",
+		"Any > Any",
+		"Any >= Any",
+		"Any < Any",
+		"Any <= Any",
+		"Any - Any",
+		"Time == Any",
+		"Time != Any",
+		"Time > Any",
+		"Time >= Any",
+		"Time < Any",
+		"Time <= Any",
+		"Time - Any",
+		"Any + Duration",
+		"Duration + Any",
+		"Time + Duration",
+		"Duration + Time",
 	}
 	for _, test := range typeTests {
 		var err error
@@ -634,6 +659,8 @@ type mockEnv2 struct {
 	BoolFn     func() bool
 	NilFn      func()
 	Variadic   func(head string, xs ...int) int
+	Time       time.Time
+	Duration   time.Duration
 }
 
 func (p mockEnv2) Method(_ bar) int {

--- a/checker/types.go
+++ b/checker/types.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/antonmedv/expr/ast"
 )
@@ -15,6 +16,8 @@ var (
 	arrayType     = reflect.TypeOf([]interface{}{})
 	mapType       = reflect.TypeOf(map[string]interface{}{})
 	interfaceType = reflect.TypeOf(new(interface{})).Elem()
+	timeType      = reflect.TypeOf(time.Time{})
+	durationType  = reflect.TypeOf(time.Duration(0))
 )
 
 func typeWeight(t reflect.Type) int {
@@ -123,6 +126,28 @@ func isFloat(t reflect.Type) bool {
 
 func isNumber(t reflect.Type) bool {
 	return isInteger(t) || isFloat(t)
+}
+
+func isTime(t reflect.Type) bool {
+	t = dereference(t)
+	if t != nil {
+		switch t {
+		case timeType:
+			return true
+		}
+	}
+	return false
+}
+
+func isDuration(t reflect.Type) bool {
+	t = dereference(t)
+	if t != nil {
+		switch t {
+		case durationType:
+			return true
+		}
+	}
+	return false
 }
 
 func isBool(t reflect.Type) bool {

--- a/checker/types.go
+++ b/checker/types.go
@@ -136,7 +136,7 @@ func isTime(t reflect.Type) bool {
 			return true
 		}
 	}
-	return false
+	return isInterface(t)
 }
 
 func isDuration(t reflect.Type) bool {

--- a/expr_test.go
+++ b/expr_test.go
@@ -474,6 +474,10 @@ func TestExpr_readme_example(t *testing.T) {
 
 func TestExpr(t *testing.T) {
 	date := time.Date(2017, time.October, 23, 18, 30, 0, 0, time.UTC)
+	tnow := time.Now()
+	oneDay, _ := time.ParseDuration("24h")
+	tnowPlusOne := tnow.Add(oneDay)
+
 	env := &mockEnv{
 		Any:     "any",
 		Int:     0,
@@ -494,12 +498,14 @@ func TestExpr(t *testing.T) {
 			{Origin: "MOW", Destination: "LED"},
 			{Origin: "LED", Destination: "MOW"},
 		},
-		BirthDay:      date,
-		Now:           time.Now(),
-		One:           1,
-		Two:           2,
-		Three:         3,
-		MultiDimArray: [][]int{{1, 2, 3}, {1, 2, 3}},
+		BirthDay:       date,
+		Now:            tnow,
+		NowPlusOne:     tnowPlusOne,
+		OneDayDuration: oneDay,
+		One:            1,
+		Two:            2,
+		Three:          3,
+		MultiDimArray:  [][]int{{1, 2, 3}, {1, 2, 3}},
 		Sum: func(list []int) int {
 			var ret int
 			for _, el := range list {
@@ -883,6 +889,46 @@ func TestExpr(t *testing.T) {
 		{
 			`Concat("a", 1, [])`,
 			`a1[]`,
+		},
+		{
+			`Tweets[0].Date < Now`,
+			true,
+		},
+		{
+			`Now > Tweets[0].Date`,
+			true,
+		},
+		{
+			`Now == Now`,
+			true,
+		},
+		{
+			`Now >= Now`,
+			true,
+		},
+		{
+			`Now <= Now`,
+			true,
+		},
+		{
+			`Now == NowPlusOne`,
+			false,
+		},
+		{
+			`Now != Now`,
+			false,
+		},
+		{
+			`Now != NowPlusOne`,
+			true,
+		},
+		{
+			`NowPlusOne - Now`,
+			oneDay,
+		},
+		{
+			`Now + OneDayDuration`,
+			tnowPlusOne,
 		},
 	}
 
@@ -1339,9 +1385,7 @@ func TestIssue138(t *testing.T) {
 	require.Error(t, err)
 }
 
-//
 // Mock types
-//
 type mockEnv struct {
 	Any                  interface{}
 	Int, One, Two, Three int
@@ -1360,6 +1404,8 @@ type mockEnv struct {
 	Segments             []*segment
 	BirthDay             time.Time
 	Now                  time.Time
+	NowPlusOne           time.Time
+	OneDayDuration       time.Duration
 	Nil                  interface{}
 	NilStruct            *time.Time
 	NilInt               *int

--- a/expr_test.go
+++ b/expr_test.go
@@ -930,6 +930,10 @@ func TestExpr(t *testing.T) {
 			`Now + OneDayDuration`,
 			tnowPlusOne,
 		},
+		{
+			`OneDayDuration + Now`,
+			tnowPlusOne,
+		},
 	}
 
 	for _, tt := range tests {

--- a/file/source_test.go
+++ b/file/source_test.go
@@ -48,8 +48,8 @@ func TestStringSource_SnippetSingleLine(t *testing.T) {
 		t.Errorf(unexpectedSnippet, t.Name(), str, "hello, world")
 	}
 	if str2, found := source.Snippet(2); found {
-		t.Error(snippetFound, t.Name(), 2)
+		t.Errorf(snippetFound, t.Name(), 2)
 	} else if str2 != "" {
-		t.Error(unexpectedSnippet, t.Name(), str2, "")
+		t.Errorf(unexpectedSnippet, t.Name(), str2, "")
 	}
 }

--- a/vm/helpers.go
+++ b/vm/helpers.go
@@ -5,6 +5,7 @@ package vm
 import (
 	"fmt"
 	"reflect"
+	"time"
 )
 
 func equal(a, b interface{}) interface{} {
@@ -337,6 +338,13 @@ func equal(a, b interface{}) interface{} {
 		switch y := b.(type) {
 		case string:
 			return x == y
+		}
+	case time.Time:
+		switch y := b.(type) {
+		case time.Time:
+			return x.Equal(y)
+		default: 
+		return false
 		}
 	}
 	if isNil(a) && isNil(b) {
@@ -676,7 +684,13 @@ func less(a, b interface{}) interface{} {
 		case string:
 			return x < y
 		}
+	case time.Time:
+		switch y := b.(type) {
+		case time.Time:
+			return x.Before(y)
+		}
 	}
+	
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "<", b))
 }
 
@@ -1011,7 +1025,13 @@ func more(a, b interface{}) interface{} {
 		case string:
 			return x > y
 		}
+	case time.Time:
+		switch y := b.(type) {
+		case time.Time:
+			return x.After(y)
+		}
 	}
+	
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, ">", b))
 }
 
@@ -1345,6 +1365,11 @@ func lessOrEqual(a, b interface{}) interface{} {
 		switch y := b.(type) {
 		case string:
 			return x <= y
+		}
+	case time.Time:
+		switch y := b.(type) {
+		case time.Time:
+			return x.Before(y) || x.Equal(y)
 		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "<=", b))
@@ -1681,6 +1706,11 @@ func moreOrEqual(a, b interface{}) interface{} {
 		case string:
 			return x >= y
 		}
+	case time.Time:
+		switch y := b.(type) {
+		case time.Time:
+			return x.After(y) || x.Equal(y)
+		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, ">=", b))
 }
@@ -2016,6 +2046,11 @@ func add(a, b interface{}) interface{} {
 		case string:
 			return x + y
 		}
+	case time.Time:
+		switch y := b.(type) {
+		case time.Duration:
+			return x.Add(y)
+		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "+", b))
 }
@@ -2345,6 +2380,11 @@ func subtract(a, b interface{}) interface{} {
 			return x - float64(y)
 		case float64:
 			return x - y
+		}
+	case time.Time:
+		switch y := b.(type) {
+		case time.Time:
+			return x.Sub(y)
 		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "-", b))

--- a/vm/helpers.go
+++ b/vm/helpers.go
@@ -2051,6 +2051,11 @@ func add(a, b interface{}) interface{} {
 		case time.Duration:
 			return x.Add(y)
 		}
+	case time.Duration:
+		switch y := b.(type) {
+		case time.Time:
+			return y.Add(x)
+		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %v %T", a, "+", b))
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -150,7 +150,7 @@ func TestRun_helpers_time(t *testing.T) {
 		{a: testTime, b: testTime, op: "+", wantErr: true},
 		{a: testTime, b: int64(1), op: "+", wantErr: true},
 		{a: testTime, b: float64(1), op: "+", wantErr: true},
-		{a: testDuration, b: testTime, op: "+", wantErr: true},
+		{a: testDuration, b: testTime, op: "+", wantErr: false},
 	}
 
 	for _, tt := range tests {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/antonmedv/expr/ast"
 	"github.com/antonmedv/expr/checker"
@@ -94,6 +95,87 @@ func TestRun_helpers(t *testing.T) {
 				require.NoError(t, err)
 			}
 		}
+	}
+}
+
+func TestRun_helpers_time(t *testing.T) {
+	testTime := time.Date(2000, time.Month(1), 1, 0, 0, 0, 0, time.UTC)
+	testDuration := time.Duration(1)
+
+	tests := []struct {
+		a       interface{}
+		b       interface{}
+		op      string
+		want    interface{}
+		wantErr bool
+	}{
+		{a: testTime, b: testTime, op: "<", wantErr: false},
+		{a: testTime, b: testTime, op: ">", wantErr: false},
+		{a: testTime, b: testTime, op: "<=", wantErr: false},
+		{a: testTime, b: testTime, op: ">=", wantErr: false},
+		{a: testTime, b: testTime, op: "==", wantErr: false},
+		{a: testTime, b: testTime, op: "-", wantErr: false},
+		{a: testTime, b: testDuration, op: "+", wantErr: false},
+
+		// error cases
+		{a: testTime, b: int64(1), op: "<", wantErr: true},
+		{a: testTime, b: float64(1), op: "<", wantErr: true},
+		{a: testTime, b: testDuration, op: "<", wantErr: true},
+
+		{a: testTime, b: int64(1), op: ">", wantErr: true},
+		{a: testTime, b: float64(1), op: ">", wantErr: true},
+		{a: testTime, b: testDuration, op: ">", wantErr: true},
+
+		{a: testTime, b: int64(1), op: "<=", wantErr: true},
+		{a: testTime, b: float64(1), op: "<=", wantErr: true},
+		{a: testTime, b: testDuration, op: "<=", wantErr: true},
+
+		{a: testTime, b: int64(1), op: ">=", wantErr: true},
+		{a: testTime, b: float64(1), op: ">=", wantErr: true},
+		{a: testTime, b: testDuration, op: ">=", wantErr: true},
+
+		{a: testTime, b: int64(1), op: "==", wantErr: false, want: false},
+		{a: testTime, b: float64(1), op: "==", wantErr: false, want: false},
+		{a: testTime, b: testDuration, op: "==", wantErr: false, want: false},
+
+		{a: testTime, b: int64(1), op: "-", wantErr: true},
+		{a: testTime, b: float64(1), op: "-", wantErr: true},
+		{a: testTime, b: testDuration, op: "-", wantErr: true},
+
+		{a: testTime, b: testTime, op: "+", wantErr: true},
+		{a: testTime, b: int64(1), op: "+", wantErr: true},
+		{a: testTime, b: float64(1), op: "+", wantErr: true},
+		{a: testDuration, b: testTime, op: "+", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("time helper test `%T %s %T`", tt.a, tt.op, tt.b), func(t *testing.T) {
+			input := fmt.Sprintf("a %v b", tt.op)
+			env := map[string]interface{}{
+				"a": tt.a,
+				"b": tt.b,
+			}
+
+			tree, err := parser.Parse(input)
+			require.NoError(t, err)
+
+			_, err = checker.Check(tree, nil)
+			require.NoError(t, err)
+
+			program, err := compiler.Compile(tree, nil)
+			require.NoError(t, err)
+
+			got, err := vm.Run(program, env)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				if tt.want != nil {
+					require.Equal(t, tt.want, got)
+				}
+			}
+		})
 	}
 }
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -109,11 +109,12 @@ func TestRun_helpers_time(t *testing.T) {
 		want    interface{}
 		wantErr bool
 	}{
-		{a: testTime, b: testTime, op: "<", wantErr: false},
-		{a: testTime, b: testTime, op: ">", wantErr: false},
-		{a: testTime, b: testTime, op: "<=", wantErr: false},
-		{a: testTime, b: testTime, op: ">=", wantErr: false},
-		{a: testTime, b: testTime, op: "==", wantErr: false},
+		{a: testTime, b: testTime, op: "<", wantErr: false, want: false},
+		{a: testTime, b: testTime, op: ">", wantErr: false, want: false},
+		{a: testTime, b: testTime, op: "<=", wantErr: false, want: true},
+		{a: testTime, b: testTime, op: ">=", wantErr: false, want: true},
+		{a: testTime, b: testTime, op: "==", wantErr: false, want: true},
+		{a: testTime, b: testTime, op: "!=", wantErr: false, want: false},
 		{a: testTime, b: testTime, op: "-", wantErr: false},
 		{a: testTime, b: testDuration, op: "+", wantErr: false},
 
@@ -137,6 +138,10 @@ func TestRun_helpers_time(t *testing.T) {
 		{a: testTime, b: int64(1), op: "==", wantErr: false, want: false},
 		{a: testTime, b: float64(1), op: "==", wantErr: false, want: false},
 		{a: testTime, b: testDuration, op: "==", wantErr: false, want: false},
+
+		{a: testTime, b: int64(1), op: "!=", wantErr: false, want: true},
+		{a: testTime, b: float64(1), op: "!=", wantErr: false, want: true},
+		{a: testTime, b: testDuration, op: "!=", wantErr: false, want: true},
 
 		{a: testTime, b: int64(1), op: "-", wantErr: true},
 		{a: testTime, b: float64(1), op: "-", wantErr: true},


### PR DESCRIPTION
This should resolve the following issues. 

#73 
#203
#227

Before starting this PR, I attempted to add support for time operators, but ended up with an impossible state b/c I cannot support `interface{} -OP- interface{}` without losing the built-in functionality of the operators. The only option I could see was to copy/paste/extend [/vm/helpers.go](https://github.com/antonmedv/expr/blob/master/vm/helpers.go). 

I decided to search the issues and found that others have run into this too. 

---- 
With this PR, the operators `==, >=, <=, <, >` are included by default allowing users to compare `time.Time` instances, returning  bool. 

The `+` operator adds a `time.Duration` to `time.Time`, returning `time.Time`
The `-` operator returns a duration representing the diff between two `time.Time` instances.

---- 
Please lmk if there are any concerns with the implementation. Please lmk if you see any gaps in the tests.  I'll be happy to fix it up. 

:)