### PR TITLE
Add VMPool, with benchmarks

### DIFF
--- a/vm/vm_pool.go
+++ b/vm/vm_pool.go
@@ -1,0 +1,26 @@
+package vm
+
+import (
+	"sync"
+)
+
+type VMPool struct {
+	pool sync.Pool
+}
+
+func NewVMPool() *VMPool {
+	return &VMPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return &VM{}
+			},
+		},
+	}
+}
+
+func (vp *VMPool) Run(program *Program, env interface{}) (out interface{}, err error) {
+	vm := vp.pool.Get().(*VM)
+	defer vp.pool.Put(vm)
+
+	return vm.Run(program, env)
+}


### PR DESCRIPTION
see: #285

benchmark results:
```
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
Benchmark_expr-12                         	 8171475	       140.1 ns/op	      32 B/op	       1 allocs/op
Benchmark_expr_reuseVm-12                 	17566074	        71.45 ns/op	       0 B/op	       0 allocs/op
Benchmark_expr_vmPool-12                  	13081728	        79.62 ns/op	       0 B/op	       0 allocs/op
Benchmark_expr_parallel-12                	27163621	        44.27 ns/op	      32 B/op	       1 allocs/op
Benchmark_expr_parallel_reuseVm-12        	64056369	        16.99 ns/op	       0 B/op	       0 allocs/op
Benchmark_expr_parallel_vmPool-12         	54264266	        21.96 ns/op	       0 B/op	       0 allocs/op
Benchmark_filter-12                       	   56790	     19093 ns/op	    2680 B/op	     176 allocs/op
Benchmark_access-12                       	10978123	       112.6 ns/op	      32 B/op	       1 allocs/op
Benchmark_accessMap-12                    	 9851262	       134.3 ns/op	      32 B/op	       1 allocs/op
Benchmark_callFunc-12                     	 1719852	       679.0 ns/op	     192 B/op	       6 allocs/op
Benchmark_callMethod-12                   	 1714387	       693.7 ns/op	     192 B/op	       6 allocs/op
Benchmark_callField-12                    	 7076781	       157.0 ns/op	      96 B/op	       2 allocs/op
Benchmark_callFast-12                     	 7459123	       157.6 ns/op	      96 B/op	       2 allocs/op
Benchmark_callConstExpr-12                	 8960920	       132.3 ns/op	      96 B/op	       2 allocs/op
Benchmark_largeStructAccess-12            	 4306720	       280.0 ns/op	      60 B/op	       4 allocs/op
Benchmark_largeNestedStructAccess-12      	 4099386	       299.7 ns/op	      61 B/op	       4 allocs/op
Benchmark_largeNestedArrayAccess-12       	     644	   1807816 ns/op	10518368 B/op	       2 allocs/op
Benchmark_realWorld-12                    	 2594124	       443.6 ns/op	     416 B/op	       2 allocs/op
Benchmark_realWorld_reuseVm-12            	 3244668	       383.7 ns/op	     384 B/op	       1 allocs/op
Benchmark_realWorld_vmPool-12             	 3074130	       394.7 ns/op	     384 B/op	       1 allocs/op
Benchmark_realWord_parallel-12            	 4786045	       244.2 ns/op	     416 B/op	       2 allocs/op
Benchmark_realWord_parallel_reuseVm-12    	 5730770	       217.3 ns/op	     384 B/op	       1 allocs/op
Benchmark_realWord_parallel_vmPool-12     	 5347173	       227.3 ns/op	     384 B/op	       1 allocs/op
Benchmark_realWorldInsane-12              	    6966	    159440 ns/op	   15753 B/op	     854 allocs/op
PASS
ok  	github.com/antonmedv/expr	36.295s
```