### PR TITLE
Clarify examples of slice behaviour

### DIFF
--- a/docs/Language-Definition.md
+++ b/docs/Language-Definition.md
@@ -185,8 +185,8 @@ Example:
 Variable `array` is `[1,2,3,4,5]`.
 
 ```
-array[1:5] == [2,3,4] 
+array[1:4] == [2,3,4]
+array[:3] == [1,2,3]
 array[3:] == [4,5]
-array[:4] == [1,2,3]
 array[:] == array
 ```

--- a/expr_test.go
+++ b/expr_test.go
@@ -868,6 +868,18 @@ func TestExpr(t *testing.T) {
 			[]int{2},
 		},
 		{
+			`Array[1:4]`,
+			[]int{2, 3, 4},
+		},
+		{
+			`Array[:3]`,
+			[]int{1, 2, 3},
+		},
+		{
+			`Array[3:]`,
+			[]int{4, 5},
+		},
+		{
 			`Array[0:5] == Array`,
 			true,
 		},


### PR DESCRIPTION
This fixes the examples in the language definition and adds a few more examples to the test suite that mirror this documentation.

The first example demonstrates the inclusive-exclusive nature of the indicies.

The middle two examples demonstrate the property of `array[:i]` not overlapping with `array[i:]`.