### PR TITLE
runtime.Fetch: add string type assertion check before trying to check if the value is a method

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -1613,6 +1613,32 @@ func TestIssue271(t *testing.T) {
 	require.Equal(t, 1.0, output)
 }
 
+type Issue346Array []Issue346Type
+
+type Issue346Type struct {
+	Bar string
+}
+
+func (i Issue346Array) Len() int {
+	return len(i)
+}
+
+func TestIssue346(t *testing.T) {
+	code := `Foo[0].Bar`
+
+	env := map[string]interface{}{
+		"Foo": Issue346Array{
+			{Bar: "bar"},
+		},
+	}
+	program, err := expr.Compile(code, expr.Env(env))
+	require.NoError(t, err)
+
+	output, err := expr.Run(program, env)
+	require.NoError(t, err)
+	require.Equal(t, "bar", output)
+}
+
 func TestCompile_allow_to_use_interface_to_get_an_element_from_map(t *testing.T) {
 	code := `{"value": "ok"}[vars.key]`
 	env := map[string]interface{}{

--- a/vm/runtime/runtime.go
+++ b/vm/runtime/runtime.go
@@ -18,9 +18,11 @@ func Fetch(from, i interface{}) interface{} {
 
 	// Methods can be defined on any type.
 	if v.NumMethod() > 0 {
-		method := v.MethodByName(i.(string))
-		if method.IsValid() {
-			return method.Interface()
+		if methodName, ok := i.(string); ok {
+			method := v.MethodByName(methodName)
+			if method.IsValid() {
+				return method.Interface()
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #346.

I'm not familiar enough with expr internals to know if this fixes the issue or hides the underlying cause.

Feel free to close it if you have a better solution.