### PR TITLE
Fixed a compilation error.

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -82,7 +82,7 @@ type Message struct {
 }
 
 func main() {
-	code := `map(filter(messages, len(.Text) > 0), .Text + Format(.timestamp))`
+	code := `map(filter(messages, len(.Text) > 0), Format(.Date) + '\t' + .Text + '\n')`
 
 	// We can use an empty instance of the struct as an environment.
 	program, err := expr.Compile(code, expr.Env(Env{}))


### PR DESCRIPTION
 There is no member named timestamp in Message.
Added some formatting for better looks.
The output now looks like this:
```
[17 Apr 23 20:34 IST	Oh My God!
 17 Apr 23 20:34 IST	How you doin?
 17 Apr 23 20:34 IST	Could I be wearing any more clothes?
]
```