### PR TITLE
feat: Add context.Context support for methods and functions

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -12,9 +12,13 @@ var (
 )
 
 type Function struct {
-	Name     string
-	Func     func(args ...interface{}) (interface{}, error)
-	Opcode   int
+	Name    string
+	Func    func(args ...interface{}) (interface{}, error)
+	Opcode  int
+	Context bool
+	// If Context is true, the reflect.Type of context.Context shall not be included
+	// in the signatures in Function.Types.
+	// Similarly, context.Context will not be included when calling Function.Validate.
 	Types    []reflect.Type
 	Validate func(args []reflect.Type) (reflect.Type, error)
 }

--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -1,6 +1,7 @@
 package builtin
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -12,15 +13,12 @@ var (
 )
 
 type Function struct {
-	Name    string
-	Func    func(args ...interface{}) (interface{}, error)
-	Opcode  int
-	Context bool
-	// If Context is true, the reflect.Type of context.Context shall not be included
-	// in the signatures in Function.Types.
-	// Similarly, context.Context will not be included when calling Function.Validate.
-	Types    []reflect.Type
-	Validate func(args []reflect.Type) (reflect.Type, error)
+	Name            string
+	Func            func(args ...interface{}) (interface{}, error)
+	FuncWithContext func(ctx context.Context, args ...interface{}) (interface{}, error)
+	Opcode          int
+	Types           []reflect.Type
+	Validate        func(args []reflect.Type) (reflect.Type, error)
 }
 
 const (

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -605,6 +605,12 @@ func (v *visitor) checkFunc(name string, fn reflect.Type, method bool, node *ast
 		fnInOffset = 1
 	}
 
+	// If first argument is context.Context, we skip it for type check.
+	if fnNumIn > 0 && fn.In(fnInOffset) == contextType {
+		fnInOffset++
+		fnNumIn--
+	}
+
 	if fn.IsVariadic() {
 		if len(node.Arguments) < fnNumIn-1 {
 			return anyType, &file.Error{

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -605,8 +605,8 @@ func (v *visitor) checkFunc(name string, fn reflect.Type, method bool, node *ast
 		fnInOffset = 1
 	}
 
-	// If first argument is context.Context, we skip it for type check.
-	if fnNumIn > 0 && fn.In(fnInOffset) == contextType {
+	// If node calls builtin.Function and it is FuncWithContext, we skip context for type check.
+	if node.Func != nil && node.Func.FuncWithContext != nil {
 		fnInOffset++
 		fnNumIn--
 	}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2,7 +2,6 @@ package checker_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -74,7 +73,6 @@ var successTests = []string{
 	"ArrayOfFoo[0:10][0].Bar.Baz == ''",
 	"!ArrayOfAny[Any]",
 	"Bool && Any",
-	"FuncCtx(true, 1, 'str')",
 	"FuncParam(true, 1, 'str')",
 	"FuncParamAny(nil)",
 	"!Fast(Any, String)",
@@ -829,14 +827,11 @@ func TestCheck_Function_types_are_checked(t *testing.T) {
 		new(func(...int) int),
 	)
 
-	addctx := expr.Function(
+	addctx := expr.FunctionWithContext(
 		"addctx",
-		func(p ...interface{}) (interface{}, error) {
-			if _, ok := p[0].(context.Context); !ok {
-				return nil, errors.New("no context")
-			}
+		func(ctx context.Context, p ...interface{}) (interface{}, error) {
 			out := 0
-			for _, each := range p[1:] {
+			for _, each := range p {
 				out += each.(int)
 			}
 			return out, nil

--- a/checker/types.go
+++ b/checker/types.go
@@ -1,6 +1,7 @@
 package checker
 
 import (
+	"context"
 	"reflect"
 	"time"
 
@@ -21,6 +22,7 @@ var (
 	durationType = reflect.TypeOf(time.Duration(0))
 	functionType = reflect.TypeOf(new(func(...interface{}) (interface{}, error))).Elem()
 	errorType    = reflect.TypeOf((*error)(nil)).Elem()
+	contextType  = reflect.TypeOf((*context.Context)(nil)).Elem()
 )
 
 func combined(a, b reflect.Type) reflect.Type {

--- a/checker/types.go
+++ b/checker/types.go
@@ -1,7 +1,6 @@
 package checker
 
 import (
-	"context"
 	"reflect"
 	"time"
 
@@ -22,7 +21,6 @@ var (
 	durationType = reflect.TypeOf(time.Duration(0))
 	functionType = reflect.TypeOf(new(func(...interface{}) (interface{}, error))).Elem()
 	errorType    = reflect.TypeOf((*error)(nil)).Elem()
-	contextType  = reflect.TypeOf((*context.Context)(nil)).Elem()
 )
 
 func combined(a, b reflect.Type) reflect.Type {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -538,6 +538,11 @@ func (c *compiler) CallNode(node *ast.CallNode) {
 			c.emit(OpBuiltin, node.Func.Opcode)
 			return
 		}
+		if node.Func.Context {
+			c.emit(OpLoadFunc, c.addFunction(node))
+			c.emit(OpCallContext, len(node.Arguments))
+			return
+		}
 		switch len(node.Arguments) {
 		case 0:
 			c.emit(OpCall0, c.addFunction(node))

--- a/conf/config.go
+++ b/conf/config.go
@@ -78,6 +78,11 @@ func (c *Config) ConstExpr(name string) {
 }
 
 func (c *Config) Check() {
+	for _, fn := range c.Functions {
+		if fn.Func != nil && fn.FuncWithContext != nil {
+			panic(fmt.Errorf("function %s shall be either with or without context, not both", fn.Name))
+		}
+	}
 	for operator, fns := range c.Operators {
 		for _, fn := range fns {
 			fnType, ok := c.Types[fn]

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -174,3 +174,18 @@ Here is another example with a few function signatures:
 		new(func(string) int),
 	)
 ```
+
+Functions taking `context.Context` as first argument are also accepted:
+
+```go
+	username := expr.FunctionWithContext(
+		"username",
+		func(params ...any) (any, error) {
+			ctx := params[0].(context.Context)
+			return ctx.Value("user"), nil
+		},
+		new(func() string),
+	)
+```
+
+Program shall be run using `expr.RunWithContext`.

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -180,11 +180,10 @@ Functions taking `context.Context` as first argument are also accepted:
 ```go
 	username := expr.FunctionWithContext(
 		"username",
-		func(params ...any) (any, error) {
-			ctx := params[0].(context.Context)
+		func(ctx context.Context, params ...any) (any, error) {
 			return ctx.Value("user"), nil
 		},
-		new(func() string),
+		new(func(context.Context) string),
 	)
 ```
 

--- a/expr.go
+++ b/expr.go
@@ -104,16 +104,15 @@ func Patch(visitor ast.Visitor) Option {
 
 // Function adds function to list of functions what will be available in expressions.
 func Function(name string, fn func(params ...interface{}) (interface{}, error), types ...interface{}) Option {
-	return function(name, fn, false, types...)
+	return function(name, fn, nil, false, types...)
 }
 
-// FunctionWithContext adds function to list of functions what will be available in expressions. First argument
-// shall be context.Context.
-func FunctionWithContext(name string, fn func(params ...interface{}) (interface{}, error), types ...interface{}) Option {
-	return function(name, fn, true, types...)
+// FunctionWithContext adds function to list of functions what will be available in expressions.
+func FunctionWithContext(name string, fnCtx func(ctx context.Context, params ...interface{}) (interface{}, error), types ...interface{}) Option {
+	return function(name, nil, fnCtx, true, types...)
 }
 
-func function(name string, fn func(params ...interface{}) (interface{}, error), context bool, types ...interface{}) Option {
+func function(name string, fn func(params ...interface{}) (interface{}, error), fnCtx func(ctx context.Context, params ...interface{}) (interface{}, error), context bool, types ...interface{}) Option {
 	return func(c *conf.Config) {
 		ts := make([]reflect.Type, len(types))
 		for i, t := range types {
@@ -127,10 +126,10 @@ func function(name string, fn func(params ...interface{}) (interface{}, error), 
 			ts[i] = t
 		}
 		c.Functions[name] = &builtin.Function{
-			Name:    name,
-			Func:    fn,
-			Types:   ts,
-			Context: context,
+			Name:            name,
+			Func:            fn,
+			FuncWithContext: fnCtx,
+			Types:           ts,
 		}
 	}
 }

--- a/test/mock/mock.go
+++ b/test/mock/mock.go
@@ -1,6 +1,9 @@
 package mock
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type Env struct {
 	Embed
@@ -25,6 +28,7 @@ type Env struct {
 	ArrayOfFoo         []Foo
 	MapOfFoo           map[string]Foo
 	MapOfAny           map[string]interface{}
+	FuncCtx            func(context.Context, bool, int, string) bool
 	FuncParam          func(_ bool, _ int, _ string) bool
 	FuncParamAny       func(_ interface{}) bool
 	FuncTooManyReturns func() (int, int, error)

--- a/test/mock/mock.go
+++ b/test/mock/mock.go
@@ -1,7 +1,6 @@
 package mock
 
 import (
-	"context"
 	"time"
 )
 
@@ -28,7 +27,6 @@ type Env struct {
 	ArrayOfFoo         []Foo
 	MapOfFoo           map[string]Foo
 	MapOfAny           map[string]interface{}
-	FuncCtx            func(context.Context, bool, int, string) bool
 	FuncParam          func(_ bool, _ int, _ string) bool
 	FuncParamAny       func(_ interface{}) bool
 	FuncTooManyReturns func() (int, int, error)

--- a/vm/opcodes.go
+++ b/vm/opcodes.go
@@ -55,6 +55,7 @@ const (
 	OpCallN
 	OpCallFast
 	OpCallTyped
+	OpCallContext
 	OpBuiltin
 	OpArray
 	OpMap

--- a/vm/program.go
+++ b/vm/program.go
@@ -223,6 +223,9 @@ func (program *Program) Disassemble() string {
 		case OpCallN:
 			argument("OpCallN")
 
+		case OpCallContext:
+			argument("OpCallContext")
+
 		case OpCallFast:
 			argument("OpCallFast")
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -15,10 +15,7 @@ import (
 )
 
 var MemoryBudget int = 1e6
-var (
-	errorType   = reflect.TypeOf((*error)(nil)).Elem()
-	contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
-)
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
 
 type Function = func(params ...interface{}) (interface{}, error)
 


### PR DESCRIPTION
Idea is to support functions of the form `func(context.Context, any...) (any, error)` (c.f. https://github.com/antonmedv/expr/issues/380).

Changes are lightweight: 

- A new OpCode is introduced for `builtin.Function` having `context.Context` as first argument,
- This setting can be set using `&builtin.Function{Context: true}`,
- For methods, type check was modified to account for such kinds of method and the runtime was updated accordingly.

The original API is not modified.

The use cases include:

- doing interruptable work with `expr`  (requests, etc.),
- my personal use case is keeping track of created objects, using the context as a poor man's DI.

Alternatives using methods:
```go
type env struct{
    context.Context
}

func (e *env) Do(s string) string {
    return s
}
```
lacks the type flexibility provided by `builtin.Function`.