### PR TITLE
env[] keyword implemented in parser

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -1815,10 +1815,10 @@ func TestEval_nil_in_maps(t *testing.T) {
 // The enclosed identifier must be in the expression env.
 func TestEnv_keyword(t *testing.T) {
 	env := map[string]interface{}{
-		"space test":             "ok",
-		"space_test":             "not ok", // Seems to be some underscore substituting happening, check that.
-		"Section 1-2a":           "ok",
-		"2015 Information Table": "ok",
+		"space test":                       "ok",
+		"space_test":                       "not ok", // Seems to be some underscore substituting happening, check that.
+		"Section 1-2a":                     "ok",
+		`c:\ndrive\2015 Information Table`: "ok",
 		"%*worst function name ever!!": func() string {
 			return "ok"
 		}(),
@@ -1836,13 +1836,12 @@ func TestEnv_keyword(t *testing.T) {
 		want interface{}
 	}{
 		{"env['space test']", "ok"},
-		{"env[space test]", "ok"},
-		{"env[Section 1-2a]", "ok"},
-		{`env['2015 Information Table']`, "ok"},
-		{"env[%*worst function name ever!!]", "ok"},
+		{"env['Section 1-2a']", "ok"},
+		{`env["c:\\ndrive\\2015 Information Table"]`, "ok"},
+		{"env['%*worst function name ever!!']", "ok"},
 		{"env('Confusing!')", "env func ok"}, // not keyword, but some function named env
-		{"env[1] + env[2]", "ok"},
-		{"1 + env[num] + env[num]", 21},
+		{"env['1'] + env['2']", "ok"},
+		{"1 + env['num'] + env['num']", 21},
 	}
 
 	for _, tt := range tests {
@@ -1874,6 +1873,8 @@ func TestEnv_keyword(t *testing.T) {
 	}{
 		{"env[this is a problem", "bad"},
 		{"env['also a problem'", "bad"},
+		{"env[space test]", "bad"},
+		{"env[1] + env[2]", "bad"},
 	}
 
 	for _, tt := range tests {

--- a/expr_test.go
+++ b/expr_test.go
@@ -1825,9 +1825,17 @@ func TestEnv_keyword(t *testing.T) {
 		"env": func(string) string {
 			return "env func ok"
 		},
-		"1":   "o",
-		"2":   "k",
-		"num": 10,
+		"1":       "o",
+		"2":       "k",
+		"num":     10,
+		"my list": []int{1, 2, 3, 4, 5},
+		"MIN": func(a, b int) int {
+			if a < b {
+				return a
+			} else {
+				return b
+			}
+		},
 	}
 
 	// No error cases
@@ -1842,6 +1850,7 @@ func TestEnv_keyword(t *testing.T) {
 		{"env('Confusing!')", "env func ok"}, // not keyword, but some function named env
 		{"env['1'] + env['2']", "ok"},
 		{"1 + env['num'] + env['num']", 21},
+		{"MIN(env['num'],0)", 0},
 	}
 
 	for _, tt := range tests {

--- a/parser/lexer/state.go
+++ b/parser/lexer/state.go
@@ -155,15 +155,7 @@ func literalIdentifier(l *lexer) stateFn {
 				return l.error("env keyword with no closing bracket")
 			}
 		} else {
-			for r := l.next(); r != ']' && r != eof; r = l.next() {
-			}
-			if r == eof {
-				return l.error("env keyword with no closing bracket")
-			} else {
-				l.backup()
-				l.emit(Identifier)
-				l.next()
-			}
+			return l.error("env keyword must have string index")
 		}
 	} else {
 		l.backup()

--- a/parser/lexer/state.go
+++ b/parser/lexer/state.go
@@ -6,6 +6,11 @@ import (
 
 type stateFn func(*lexer) stateFn
 
+// The lexer works as a state machine, creating and emitting tokens
+// as it proceeds through the input file (string).  State changes with the
+// context of what characters have been encountered so far. This is the
+// initial state; when a change is detected, it returns the function  for the
+// relevant next state to proceed.
 func root(l *lexer) stateFn {
 	switch r := l.next(); {
 	case r == eof:
@@ -119,11 +124,50 @@ loop:
 				return not
 			case "in", "or", "and", "matches", "contains", "startsWith", "endsWith":
 				l.emit(Operator)
+			case "env":
+				return literalIdentifier
 			default:
 				l.emit(Identifier)
 			}
 			break loop
 		}
+	}
+	return root
+}
+
+// Process what comes after the env keyword, which must be any
+// set of characters or a string literal, enclosed in square brackets
+func literalIdentifier(l *lexer) stateFn {
+	// Be very strict about syntax so as not to break someone's "env" identifier
+	if l.next() == '[' {
+		l.ignore() // Forget about the "env" keyword and its opening bracket
+		if r := l.next(); r == '\'' || r == '"' {
+			l.scanString(r)
+			str, err := unescape(l.word())
+			if err != nil {
+				l.error("%v", err)
+			}
+			if l.next() == ']' {
+				l.backup()
+				l.emitValue(Identifier, str)
+				l.next()
+			} else {
+				return l.error("env keyword with no closing bracket")
+			}
+		} else {
+			for r := l.next(); r != ']' && r != eof; r = l.next() {
+			}
+			if r == eof {
+				return l.error("env keyword with no closing bracket")
+			} else {
+				l.backup()
+				l.emit(Identifier)
+				l.next()
+			}
+		}
+	} else {
+		l.backup()
+		l.emit(Identifier)
 	}
 	return root
 }

--- a/parser/lexer/state.go
+++ b/parser/lexer/state.go
@@ -148,9 +148,8 @@ func literalIdentifier(l *lexer) stateFn {
 				l.error("%v", err)
 			}
 			if l.next() == ']' {
-				l.backup()
+				l.ignore()
 				l.emitValue(Identifier, str)
-				l.next()
 			} else {
 				return l.error("env keyword with no closing bracket")
 			}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -560,11 +560,22 @@ func (p *parser) parsePostfixExpression(node Node) Node {
 					p.expect(Bracket, "]")
 
 				} else {
-					// Slice operator [:] was not found,
-					// it should be just an index node.
-					node = &MemberNode{
-						Node:     node,
-						Property: from,
+					// env keyword "promotes" a string index to an identifier
+					if idNode, ok := (node).(*IdentifierNode); ok && idNode.Value == "env" {
+						if stNode, ok := (from).(*StringNode); ok {
+							node = &IdentifierNode{
+								Value: stNode.Value,
+							}
+						} else {
+							p.error("expected string index for env keyword")
+						}
+					} else {
+						// Slice operator [:] was not found,
+						// it should be just an index node.
+						node = &MemberNode{
+							Node:     node,
+							Property: from,
+						}
 					}
 					node.SetLocation(postfixToken.Location)
 					p.expect(Bracket, "]")


### PR DESCRIPTION
The env[] keyword allows an expression to access identifiers in env directly, with any name desired, including numbers, spaces, special characters, etc. Syntax env['string identifier'] and env["string identifier"] are allowable.