### PR TITLE
ExprNative interface - Allow easier use of custom types that can be represented by go builtin types

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -526,3 +526,90 @@ func Benchmark_reduce(b *testing.B) {
 
 	require.Equal(b, 5050, out.(int))
 }
+
+func Benchmark_nativeAdd(b *testing.B) {
+	env := make(map[string]any)
+
+	env["testOne"] = 1
+	env["testTwo"] = 2
+
+	program, err := expr.Compile("testOne + testTwo", expr.Env(env))
+	require.NoError(b, err)
+
+	var out any
+	v := vm.VM{}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, err = v.Run(program, env)
+	}
+	b.StopTimer()
+
+	require.NoError(b, err)
+	require.Equal(b, 3, out.(int))
+}
+
+func Benchmark_nativeEnabledAdd(b *testing.B) {
+	env := make(map[string]any)
+
+	env["testOne"] = 1
+	env["testTwo"] = 2
+
+	program, err := expr.Compile("testOne + testTwo", expr.ExprNative(true), expr.Env(env))
+	require.NoError(b, err)
+
+	var out any
+	v := vm.VM{}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, err = v.Run(program, env)
+	}
+	b.StopTimer()
+
+	require.NoError(b, err)
+	require.Equal(b, 3, out.(int))
+}
+
+func Benchmark_exprNativeAdd(b *testing.B) {
+	env := make(map[string]any)
+
+	env["testOne"] = &exprNativeInt{MyInt: 1}
+	env["testTwo"] = &exprNativeInt{MyInt: 2}
+
+	program, err := expr.Compile("testOne + testTwo", expr.ExprNative(true), expr.Env(env))
+	require.NoError(b, err)
+
+	var out any
+	v := vm.VM{}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, err = v.Run(program, env)
+	}
+	b.StopTimer()
+
+	require.NoError(b, err)
+	require.Equal(b, 3, out.(int))
+}
+
+func Benchmark_callAdd(b *testing.B) {
+	env := make(map[string]any)
+
+	env["testOne"] = &exprNativeInt{MyInt: 1}
+	env["testTwo"] = &exprNativeInt{MyInt: 2}
+
+	program, err := expr.Compile("testOne.Value() + testTwo.Value()", expr.Env(env))
+	require.NoError(b, err)
+
+	var out any
+	v := vm.VM{}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, err = v.Run(program, env)
+	}
+	b.StopTimer()
+
+	require.NoError(b, err)
+	require.Equal(b, 3, out.(int))
+}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -57,6 +57,7 @@ func Compile(tree *parser.Tree, config *conf.Config) (program *Program, err erro
 		Arguments: c.arguments,
 		Functions: c.functions,
 		DebugInfo: c.debugInfo,
+		ExprNative: config.ExprNative,
 	}
 	return
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -57,7 +57,10 @@ func Compile(tree *parser.Tree, config *conf.Config) (program *Program, err erro
 		Arguments: c.arguments,
 		Functions: c.functions,
 		DebugInfo: c.debugInfo,
-		ExprNative: config.ExprNative,
+	}
+
+	if config != nil {
+		program.ExprNative = config.ExprNative
 	}
 	return
 }

--- a/conf/config.go
+++ b/conf/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	ExpectAny   bool
 	Optimize    bool
 	Strict      bool
+	ExprNative  bool
 	ConstFns    map[string]reflect.Value
 	Visitors    []ast.Visitor
 	Functions   map[string]*ast.Function
@@ -61,7 +62,7 @@ func (c *Config) WithEnv(env any) {
 	}
 
 	c.Env = env
-	c.Types = CreateTypesTable(env)
+	c.Types = CreateTypesTable(env, c.ExprNative)
 	c.MapEnv = mapEnv
 	c.DefaultType = mapValueType
 	c.Strict = true

--- a/conf/types_table.go
+++ b/conf/types_table.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"github.com/antonmedv/expr/vm"
 	"reflect"
 )
 
@@ -20,7 +21,7 @@ type TypesTable map[string]Tag
 //
 // If map is passed, all items will be treated as variables
 // (key as name, value as type).
-func CreateTypesTable(i any) TypesTable {
+func CreateTypesTable(i any, exprNative bool) TypesTable {
 	if i == nil {
 		return nil
 	}
@@ -57,7 +58,16 @@ func CreateTypesTable(i any) TypesTable {
 				if key.String() == "$env" { // Could check for all keywords here
 					panic("attempt to misuse env keyword as env map key")
 				}
-				types[key.String()] = Tag{Type: reflect.TypeOf(value.Interface())}
+
+				v := value.Interface()
+				if exprNative {
+					if ev, ok := v.(vm.ExprNative); ok {
+						types[key.String()] = Tag{Type: ev.ExprNativeType()}
+						continue
+					}
+				}
+
+				types[key.String()] = Tag{Type: reflect.TypeOf(v)}
 			}
 		}
 

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -83,7 +83,7 @@ func CreateDoc(i any) *Context {
 		PkgPath:   dereference(reflect.TypeOf(i)).PkgPath(),
 	}
 
-	for name, t := range conf.CreateTypesTable(i) {
+	for name, t := range conf.CreateTypesTable(i, false) {
 		if t.Ambiguous {
 			continue
 		}

--- a/expr.go
+++ b/expr.go
@@ -100,6 +100,15 @@ func Optimize(b bool) Option {
 	}
 }
 
+// ExprNative sets a flag in compiled program teling the runtime to use the value return by ExprNative interface instead of the direct variable
+// This option must be passed BEFORE the Env() option during the compile phase or type checking will most likely be broken
+// Only applies to map environments
+func ExprNative(b bool) Option {
+	return func(c *conf.Config) {
+		c.ExprNative = b
+	}
+}
+
 // Patch adds visitor to list of visitors what will be applied before compiling AST to bytecode.
 func Patch(visitor ast.Visitor) Option {
 	return func(c *conf.Config) {

--- a/expr_test.go
+++ b/expr_test.go
@@ -435,6 +435,68 @@ func ExampleAllowUndefinedVariables_zero_value_functions() {
 	// Output: [foo bar]
 }
 
+type exprNativeInt struct {
+	MyInt int
+}
+
+func (n *exprNativeInt) ExprNativeValue() any {
+	return n.MyInt
+}
+
+func (n *exprNativeInt) ExprNativeType() reflect.Type {
+	return reflect.TypeOf(n.MyInt)
+}
+
+func (n *exprNativeInt) Value() int {
+	return n.MyInt
+}
+
+func ExampleExprNative() {
+	env := make(map[string]any)
+
+	env["testOne"] = &exprNativeInt{MyInt: 1}
+	env["testTwo"] = &exprNativeInt{MyInt: 2}
+
+	program, err := expr.Compile("testOne + testTwo", expr.ExprNative(true), expr.Env(env))
+	if err != nil {
+		fmt.Printf("%v", err)
+		return
+	}
+
+	output, err := expr.Run(program, env)
+	if err != nil {
+		fmt.Printf("%v", err)
+		return
+	}
+
+	fmt.Printf("%T(%v)", output, output)
+
+	// Output: int(3)
+}
+
+func ExampleCallAdd() {
+	env := make(map[string]any)
+
+	env["testOne"] = &exprNativeInt{MyInt: 1}
+	env["testTwo"] = &exprNativeInt{MyInt: 2}
+
+	program, err := expr.Compile("testOne.Value() + testTwo.Value()", expr.Env(env))
+	if err != nil {
+		fmt.Printf("%v", err)
+		return
+	}
+
+	output, err := expr.Run(program, env)
+	if err != nil {
+		fmt.Printf("%v", err)
+		return
+	}
+
+	fmt.Printf("%T(%v)", output, output)
+
+	// Output: int(3)
+}
+
 type patcher struct{}
 
 func (p *patcher) Visit(node *ast.Node) {

--- a/vm/program.go
+++ b/vm/program.go
@@ -16,15 +16,16 @@ import (
 )
 
 type Program struct {
-	Node      ast.Node
-	Source    *file.Source
-	Locations []file.Location
-	Variables []any
-	Constants []any
-	Bytecode  []Opcode
-	Arguments []int
-	Functions []Function
-	DebugInfo map[string]string
+	Node       ast.Node
+	Source     *file.Source
+	Locations  []file.Location
+	Variables  []any
+	Constants  []any
+	Bytecode   []Opcode
+	Arguments  []int
+	Functions  []Function
+	DebugInfo  map[string]string
+	ExprNative bool
 }
 
 func (program *Program) Disassemble() string {


### PR DESCRIPTION
This patch set adds the ExprNative interface which allows a type to present itself as a expr native/friendly type for evaluation.

```
type ExprNative interface {
	// ExprNativeValue returns a native value that expr can use directly
	ExprNativeValue() any
	// ExprNativeType returns the reflect.Type of the type that will be returned by ExprNativeValue
	ExprNativeType() reflect.Type
}
```

This interface currently lives in the `vm` package. Not sure if there is a better placement for it.

It is controlled by the ExprNative() Option. This is set at compile time and is a Program level flag.

```
// ExprNative sets a flag in compiled program teling the runtime to use the value return by ExprNative interface instead of the direct variable
// This option must be passed BEFORE the Env() option during the compile phase or type checking will most likely be broken
// Only applies to map environments
func ExprNative(b bool) Option {
        return func(c *conf.Config) {
                c.ExprNative = b
        }
}
```

The goal is to make it easier to use custom types in expr when they can be represented as builtin go types.

My personal use case is that I am using map[string]interface{} to represent a database record, but the values stored are custom types based on the database column type with additional metadata.

Something along the lines of:

```
type MyDBInt struct {
        MyInt int
        // Additional Meta Info Here
}
```

In order to use them with expr there are a few options:
* Build a new map[string]interface{} env that I populate with the go builtin values to use with calls to expr. However the results of the expression may used change a value in the record, which may mean having to rebuild the env on every call, or additional book keeping.
* Provide a function for the types to retrieve the builtin value at runtime (which is not the most ergonomic).
* Overloading, but I have multiple types (representing database column types) and this quickly grows out of hand. Being able to reuse the builtin expr operators and functions is much more ideal.

With the ExprNative interface they can be addressed directly in expressions, which allows me to reuse my already present map[string]interface{} and not have to rebuild or book-keep a separate env.

#### Performance and Benchmarks
We add a check in vm.push() so that before a value is pushed to the stack it is converted to the native type. vm.push() is hot path location, so we guard the type cast behind a configuration setting to prevent a as much of a performance regression as possible

```
                         │      sec/op      │   sec/op     vs base                │
_expr                           184.8n ± 2%   189.8n ± 2%   +2.73% (p=0.003 n=10)
_expr_reuseVm                   115.9n ± 1%   120.8n ± 1%   +4.18% (p=0.000 n=10)
_len                            103.0n ± 2%   103.2n ± 1%        ~ (p=0.927 n=10)
_filter                         134.7µ ± 3%   160.0µ ± 1%  +18.78% (p=0.000 n=10)
_filterLen                      121.1µ ± 1%   145.0µ ± 1%  +19.74% (p=0.000 n=10)
_filterFirst                    1.196µ ± 2%   1.352µ ± 2%  +12.95% (p=0.000 n=10)
_filterLast                     2.220µ ± 1%   2.341µ ± 1%   +5.45% (p=0.000 n=10)
_filterMap                      14.13µ ± 1%   16.48µ ± 1%  +16.62% (p=0.000 n=10)
_arrayIndex                     161.0n ± 0%   174.0n ± 3%   +8.04% (p=0.000 n=10)
_envStruct                      124.2n ± 2%   121.7n ± 1%   -2.01% (p=0.000 n=10)
_envMap                         138.3n ± 2%   138.6n ± 1%        ~ (p=0.753 n=10)
_callFunc                       823.1n ± 1%   840.4n ± 1%   +2.10% (p=0.000 n=10)
_callMethod                     869.3n ± 2%   885.2n ± 1%   +1.82% (p=0.000 n=10)
_callField                      160.3n ± 1%   165.8n ± 1%   +3.43% (p=0.000 n=10)
_callFast                       164.2n ± 4%   168.1n ± 1%   +2.34% (p=0.027 n=10)
_callConstExpr                  132.8n ± 1%   130.8n ± 1%   -1.51% (p=0.001 n=10)
_largeStructAccess              315.6n ± 1%   331.4n ± 1%   +5.02% (p=0.000 n=10)
_largeNestedStructAccess        341.8n ± 1%   347.9n ± 2%   +1.81% (p=0.001 n=10)
_largeNestedArrayAccess         1.369m ± 1%   1.366m ± 0%        ~ (p=0.315 n=10)
_sort                           14.82µ ± 1%   14.85µ ± 1%        ~ (p=0.987 n=10)
_sortBy                         25.17µ ± 5%   24.79µ ± 3%        ~ (p=0.139 n=10)
_groupBy                        22.84µ ± 2%   23.53µ ± 1%   +3.06% (p=0.003 n=10)
_reduce                         11.64µ ± 1%   11.67µ ± 1%        ~ (p=0.353 n=10)
geomean                         1.672µ        1.745µ        +4.33%

```
I'm not sure if there is any way to reduce this further. Or a better place in the pipeline to do the conversion.

I also added some benchmarks to compare it on/off and against calling a function to get the value.

```
Benchmark_nativeAdd             12200732                93.85 ns/op
Benchmark_nativeEnabledAdd       8604038               136.9 ns/op
Benchmark_exprNativeAdd          8606650               140.9 ns/op
Benchmark_callAdd                 761148              1525 ns/op
```

The benchmark shows that most of the performance hit from enabling and disabling the option are from the type cast check, and that it is much faster than using a function call on the type.

Anecdotally it is also about 2x faster than creating a new map and converting values for each call to env.

I think it provides a nice usability enhancement to `expr` and look forward to your feedback.