### PR TITLE
Do not repeat patcher definition in ExamplePatch()

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -504,20 +504,6 @@ func (p *patcher) Visit(node *ast.Node) {
 }
 
 func ExamplePatch() {
-	/*
-		type patcher struct{}
-
-		func (p *patcher) Visit(node *ast.Node) {
-			switch n := (*node).(type) {
-			case *ast.MemberNode:
-				ast.Patch(node, &ast.CallNode{
-					Callee:    &ast.IdentifierNode{Value: "get"},
-					Arguments: []ast.Node{n.Node, n.Property},
-				})
-			}
-		}
-	*/
-
 	program, err := expr.Compile(
 		`greet.you.world + "!"`,
 		expr.Patch(&patcher{}),


### PR DESCRIPTION
I suppose at some point, godoc was not smart enough to display the definitions used in the body of examples in the documentation. This is not the case anymore: https://pkg.go.dev/github.com/expr-lang/expr#example-Patch