### PR TITLE
Make ast.Node return *nature.Nature

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -15,7 +15,7 @@ var (
 type Node interface {
 	Location() file.Location
 	SetLocation(file.Location)
-	Nature() nature.Nature
+	Nature() *nature.Nature
 	SetNature(nature.Nature)
 	Type() reflect.Type
 	SetType(reflect.Type)
@@ -47,8 +47,8 @@ func (n *base) SetLocation(loc file.Location) {
 }
 
 // Nature returns the nature of the node.
-func (n *base) Nature() nature.Nature {
-	return n.nature
+func (n *base) Nature() *nature.Nature {
+	return &n.nature
 }
 
 // SetNature sets the nature of the node.

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -635,8 +635,7 @@ func (v *Checker) callNode(node *ast.CallNode) Nature {
 	// checker pass we should replace anyType on method node
 	// with new correct function return type.
 	if typ := node.Type(); typ != nil && typ != anyType {
-		nt := node.Nature()
-		return nt
+		return *node.Nature()
 	}
 
 	nt := v.visit(node.Callee)

--- a/checker/info.go
+++ b/checker/info.go
@@ -15,8 +15,7 @@ func FieldIndex(c *Cache, env Nature, node ast.Node) (bool, []int, string) {
 			return true, idx, n.Value
 		}
 	case *ast.MemberNode:
-		base := n.Node.Nature()
-		base = base.Deref(c)
+		base := n.Node.Nature().Deref(c)
 		if base.Kind == reflect.Struct {
 			if prop, ok := n.Property.(*ast.StringNode); ok {
 				if idx, ok := base.FieldIndex(c, prop.Value); ok {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1088,8 +1088,7 @@ func (c *compiler) BuiltinNode(node *ast.BuiltinNode) {
 		for i, arg := range node.Arguments {
 			c.compile(arg)
 			argType := arg.Type()
-			argNature := arg.Nature()
-			if argType.Kind() == reflect.Ptr || argNature.IsUnknown(c.ntCache) {
+			if argType.Kind() == reflect.Ptr || arg.Nature().IsUnknown(c.ntCache) {
 				if f.Deref == nil {
 					// By default, builtins expect arguments to be dereferenced.
 					c.emit(OpDeref)


### PR DESCRIPTION
Fix #839

We keep using `nature.Nature` instead of `*nature.Nature` inside of `ast.base` because this reduces the number of checks and makes the implementation safer. Also, we always assume that we will have a nature, and the zero value of a nature is also useful, so no need to ever return `nil`.

@antonmedv this actually resulted in a minor performance improvement in several places and it also makes code more readable as you suggested :smiley: 

<details><summary>Checker benchmarks</summary>

```go
goos: linux
goarch: amd64
pkg: github.com/expr-lang/expr/checker
cpu: 13th Gen Intel(R) Core(TM) i7-13700H   
                                            │ bench-results-old.txt │      bench-results-stable.txt      │
                                            │        sec/op         │   sec/op     vs base               │
Checker/name=function_calls-20                          4.658µ ± 3%   4.620µ ± 2%       ~ (p=0.218 n=10)
Checker/name=unary_and_binary_operations-20             4.512µ ± 2%   4.502µ ± 1%       ~ (p=0.697 n=10)
Checker/name=deep_struct_access-20                      12.31µ ± 1%   12.17µ ± 1%  -1.11% (p=0.002 n=10)
geomean                                                 6.371µ        6.326µ       -0.71%

                                            │ bench-results-old.txt │      bench-results-stable.txt       │
                                            │         B/op          │    B/op     vs base                 │
Checker/name=function_calls-20                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Checker/name=unary_and_binary_operations-20            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Checker/name=deep_struct_access-20                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                           ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean   

                                            │ bench-results-old.txt │      bench-results-stable.txt       │
                                            │       allocs/op       │ allocs/op   vs base                 │
Checker/name=function_calls-20                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Checker/name=unary_and_binary_operations-20            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Checker/name=deep_struct_access-20                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                           ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

</details> 