### PR TITLE
fix(checker): array type in conditional op

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -1277,6 +1277,13 @@ func (v *Checker) conditionalNode(node *ast.ConditionalNode) Nature {
 		return v.config.NtCache.NatureOf(nil)
 	}
 	if t1.AssignableTo(t2) {
+		if t1.IsArray() && t2.IsArray() {
+			e1 := t1.Elem(&v.config.NtCache)
+			e2 := t2.Elem(&v.config.NtCache)
+			if !e1.AssignableTo(e2) || !e2.AssignableTo(e1) {
+				return v.config.NtCache.FromType(arrayType)
+			}
+		}
 		return t1
 	}
 	return Nature{}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -134,6 +134,7 @@ func TestCheck(t *testing.T) {
 		{"Bool ?? Bool"},
 		{"let foo = 1; foo == 1"},
 		{"(Embed).EmbedPointerEmbedInt > 0"},
+		{"(true ? [1] : [[1]])[0][0] == 1"},
 	}
 
 	c := new(checker.Checker)

--- a/test/issues/819/issue_test.go
+++ b/test/issues/819/issue_test.go
@@ -1,0 +1,36 @@
+package issue_test
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/internal/testify/require"
+)
+
+func TestIssue819(t *testing.T) {
+	t.Run("case 1", func(t *testing.T) {
+		program, err := expr.Compile(`
+			let a = [1];
+			let b = type(a[0]) == 'array' ? a : [a];
+			b[0][0]
+		`)
+		require.NoError(t, err)
+
+		out, err := expr.Run(program, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, out)
+	})
+
+	t.Run("case 2", func(t *testing.T) {
+		program, err := expr.Compile(`
+			let range = [1,1000];
+			let arr = false ? range : [range];
+			map(arr, {len(#)})
+		`)
+		require.NoError(t, err)
+
+		out, err := expr.Run(program, nil)
+		require.NoError(t, err)
+		require.Equal(t, []interface{}{2}, out)
+	})
+}


### PR DESCRIPTION
Correctly handle mixed array types (e.g. `[]int` vs `[][]int`) in ternary expressions by falling back to generic array type when element types differ.

Fixes #819 