### PR TITLE
fix(builtin): limit recursion depth

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -16,6 +17,10 @@ import (
 var (
 	Index map[string]int
 	Names []string
+
+	// MaxDepth limits the recursion depth for nested structures.
+	MaxDepth      = 10000
+	ErrorMaxDepth = errors.New("recursion depth exceeded")
 )
 
 func init() {
@@ -377,7 +382,7 @@ var Builtins = []*Function{
 	{
 		Name: "max",
 		Func: func(args ...any) (any, error) {
-			return minMax("max", runtime.Less, args...)
+			return minMax("max", runtime.Less, 0, args...)
 		},
 		Validate: func(args []reflect.Type) (reflect.Type, error) {
 			return validateAggregateFunc("max", args)
@@ -386,7 +391,7 @@ var Builtins = []*Function{
 	{
 		Name: "min",
 		Func: func(args ...any) (any, error) {
-			return minMax("min", runtime.More, args...)
+			return minMax("min", runtime.More, 0, args...)
 		},
 		Validate: func(args []reflect.Type) (reflect.Type, error) {
 			return validateAggregateFunc("min", args)
@@ -395,7 +400,7 @@ var Builtins = []*Function{
 	{
 		Name: "mean",
 		Func: func(args ...any) (any, error) {
-			count, sum, err := mean(args...)
+			count, sum, err := mean(0, args...)
 			if err != nil {
 				return nil, err
 			}
@@ -411,7 +416,7 @@ var Builtins = []*Function{
 	{
 		Name: "median",
 		Func: func(args ...any) (any, error) {
-			values, err := median(args...)
+			values, err := median(0, args...)
 			if err != nil {
 				return nil, err
 			}
@@ -940,7 +945,10 @@ var Builtins = []*Function{
 			if v.Kind() != reflect.Array && v.Kind() != reflect.Slice {
 				return nil, size, fmt.Errorf("cannot flatten %s", v.Kind())
 			}
-			ret := flatten(v)
+			ret, err := flatten(v, 0)
+			if err != nil {
+				return nil, 0, err
+			}
 			size = uint(len(ret))
 			return ret, size, nil
 		},


### PR DESCRIPTION
## Motivation

The builtin functions `flatten`, `min`, `max`, `mean`, and `median` recursively traverse nested arrays. If the environment provides a deeply nested structure or one containing a cycle (e.g., a slice containing itself), these functions would recurse indefinitely until the Go runtime panics due to stack overflow. This panic is unrecoverable and crashes the host application, presenting a DoS risk.

## Changes

The `builtin` package now has a `MaxDepth` integer (defaults to 10k).

These recursive helper functions now accept a `depth` argument. This is incremented on recursive calls, and errors propagate up the stack if limit is exceeded. Initial function definitions call the helpers with an initial depth of 0 and handle returned errors.

## Tests

Added various tests for the affected builtin functions using self-referencing slices. Also a test about customising the MaxDepth for users who rely on expr-lang as a library, and need more or less depth.