### PR TITLE
feat: implement proxies support

### DIFF
--- a/vm/runtime/runtime.go
+++ b/vm/runtime/runtime.go
@@ -13,17 +13,12 @@ import (
 // Proxy is an interface that allows intercepting object property access.
 type Proxy interface {
 	// GetProperty returns the value of the property with the given key.
-	GetProperty(key any) (any, bool)
+	GetProperty(key any) any
 }
 
 func Fetch(from, i any) any {
 	if proxy, ok := from.(Proxy); ok {
-		r, ok := proxy.GetProperty(i)
-		if !ok {
-			panic(fmt.Sprintf("cannot fetch %v from proxy", i))
-		}
-
-		return r
+		return proxy.GetProperty(i)
 	}
 
 	v := reflect.ValueOf(from)

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -275,14 +275,14 @@ type proxyNode struct {
 	values map[any]any
 }
 
-func (n *proxyNode) GetProperty(key any) (any, bool) {
+func (n *proxyNode) GetProperty(key any) any {
 	if value, ok := n.values[key]; ok {
-		return value, true
+		return value
 	}
 	if n.parent != nil {
 		return n.parent.GetProperty(key)
 	}
-	return nil, false
+	return nil
 }
 
 func (n *proxyNode) SetProperty(key any, value any) {


### PR DESCRIPTION
This PR adds support of proxies. Proxies allow intercepting property access, like Python's `__get__` magic method.

Proxies allow implementing different patterns like prototype chaining, read on demand, etc.

Fixes: https://github.com/expr-lang/expr/issues/777