### PR TITLE
feat: support byte slice in matches operator

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -462,7 +462,7 @@ func (v *Checker) binaryNode(node *ast.BinaryNode) Nature {
 				return v.error(node, err.Error())
 			}
 		}
-		if l.IsString() && r.IsString() {
+		if (l.IsString() || l.IsByteSlice()) && r.IsString() {
 			return v.config.NtCache.FromType(boolType)
 		}
 		if l.MaybeCompatible(&v.config.NtCache, r, StringCheck) {

--- a/checker/nature/nature.go
+++ b/checker/nature/nature.go
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	intType      = reflect.TypeOf(0)
-	floatType    = reflect.TypeOf(float64(0))
-	arrayType    = reflect.TypeOf([]any{})
-	timeType     = reflect.TypeOf(time.Time{})
-	durationType = reflect.TypeOf(time.Duration(0))
+	intType       = reflect.TypeOf(0)
+	floatType     = reflect.TypeOf(float64(0))
+	arrayType     = reflect.TypeOf([]any{})
+	byteSliceType = reflect.TypeOf([]byte{})
+	timeType      = reflect.TypeOf(time.Time{})
+	durationType  = reflect.TypeOf(time.Duration(0))
 
 	builtinInt = map[reflect.Type]struct{}{
 		reflect.TypeOf(int(0)):     {},
@@ -500,6 +501,10 @@ func (n *Nature) IsBool() bool {
 
 func (n *Nature) IsString() bool {
 	return n.Kind == reflect.String
+}
+
+func (n *Nature) IsByteSlice() bool {
+	return n.Type == byteSliceType
 }
 
 func (n *Nature) IsArray() bool {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -299,7 +299,13 @@ func (vm *VM) Run(program *Program, env any) (_ any, err error) {
 				vm.push(false)
 				break
 			}
-			match, err := regexp.MatchString(b.(string), a.(string))
+			var match bool
+			var err error
+			if s, ok := a.(string); ok {
+				match, err = regexp.MatchString(b.(string), s)
+			} else {
+				match, err = regexp.Match(b.(string), a.([]byte))
+			}
 			if err != nil {
 				panic(err)
 			}
@@ -312,7 +318,11 @@ func (vm *VM) Run(program *Program, env any) (_ any, err error) {
 				break
 			}
 			r := program.Constants[arg].(*regexp.Regexp)
-			vm.push(r.MatchString(a.(string)))
+			if s, ok := a.(string); ok {
+				vm.push(r.MatchString(s))
+			} else {
+				vm.push(r.Match(a.([]byte)))
+			}
 
 		case OpContains:
 			b := vm.pop()

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -368,6 +368,18 @@ func TestVM_OpcodeOperations(t *testing.T) {
 			expr: `"hello123" matches "^hello\\d+$"`,
 			want: true,
 		},
+		{
+			name: "byte slice matches regex",
+			expr: `b matches "^hello\\d+$"`,
+			env:  map[string]any{"b": []byte("hello123")},
+			want: true,
+		},
+		{
+			name: "byte slice matches dynamic regex",
+			expr: `b matches pattern`,
+			env:  map[string]any{"b": []byte("hello123"), "pattern": "^hello\\d+$"},
+			want: true,
+		},
 
 		// Data Structure Operations
 		{


### PR DESCRIPTION
The matches operator now supports matching against byte slices in addition to strings. This allows expressions like `b matches "pattern"` where `b` is a byte slice.

Fixes #685.