### PR TITLE
fix(checker): correct variadic method arg type

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -1112,7 +1112,7 @@ func (v *Checker) checkArguments(
 		if isVariadic && i >= fnNumIn-1 {
 			// For variadic arguments fn(xs ...int), go replaces type of xs (int) with ([]int).
 			// As we compare arguments one by one, we need underling type.
-			in = fn.InElem(&v.config.NtCache, fnNumIn-1)
+			in = fn.InElem(&v.config.NtCache, fnNumIn-1+fnInOffset)
 		} else {
 			in = fn.In(&v.config.NtCache, i+fnInOffset)
 		}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -135,6 +135,7 @@ func TestCheck(t *testing.T) {
 		{"let foo = 1; foo == 1"},
 		{"(Embed).EmbedPointerEmbedInt > 0"},
 		{"(true ? [1] : [[1]])[0][0] == 1"},
+		{"Foo.VariadicMethod('a', 'b', 'c')"},
 	}
 
 	c := new(checker.Checker)

--- a/test/issues/888/issue_test.go
+++ b/test/issues/888/issue_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/internal/testify/require"
+)
+
+type Container struct {
+	ID   string
+	List []string
+}
+
+func (c Container) IncludesAny(s ...string) bool {
+	for _, l := range c.List {
+		// Note: original issue used "slices.Contains" but
+		// it is not available in the minimum Go version of expr (1.18).
+		for _, v := range s {
+			if v == l {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestIssue888(t *testing.T) {
+	env := map[string]any{
+		"Container": Container{
+			ID:   "id",
+			List: []string{"foo", "bar", "baz"},
+		},
+	}
+
+	code := `Container.IncludesAny("nope", "nope again", "bar")`
+
+	program, err := expr.Compile(code, expr.Env(env))
+	require.NoError(t, err)
+
+	output, err := expr.Run(program, env)
+	require.NoError(t, err)
+	require.Equal(t, true, output)
+}

--- a/test/mock/mock.go
+++ b/test/mock/mock.go
@@ -186,6 +186,10 @@ func (Foo) String() string {
 	return "Foo.String"
 }
 
+func (Foo) VariadicMethod(_ ...string) bool {
+	return true
+}
+
 type Bar struct {
 	Baz string
 }


### PR DESCRIPTION
When checking arguments for variadic methods, the index passed to InElem used "fnNumIn-1", but fnNumIn had already been decremented to exclude the receiver. This caused InElem to access the receiver type (index 0) instead of the variadic parameter type, causing a type error ("cannot use string as argument").

Add "fnInOffset" to the index calculation to correctly reference the variadic parameter. Regression tests included.

Fixes #888.