### PR TITLE
perf(optimizer): count comparisons to any

### DIFF
--- a/optimizer/count_any.go
+++ b/optimizer/count_any.go
@@ -1,0 +1,36 @@
+package optimizer
+
+import (
+	. "github.com/expr-lang/expr/ast"
+)
+
+// countAny optimizes count comparisons to use any for early termination.
+// Patterns:
+//   - count(arr, pred) > 0  → any(arr, pred)
+//   - count(arr, pred) >= 1 → any(arr, pred)
+type countAny struct{}
+
+func (*countAny) Visit(node *Node) {
+	binary, ok := (*node).(*BinaryNode)
+	if !ok {
+		return
+	}
+
+	count, ok := binary.Left.(*BuiltinNode)
+	if !ok || count.Name != "count" || len(count.Arguments) != 2 {
+		return
+	}
+
+	integer, ok := binary.Right.(*IntegerNode)
+	if !ok {
+		return
+	}
+
+	if (binary.Operator == ">" && integer.Value == 0) ||
+		(binary.Operator == ">=" && integer.Value == 1) {
+		patchCopyType(node, &BuiltinNode{
+			Name:      "any",
+			Arguments: count.Arguments,
+		})
+	}
+}

--- a/optimizer/count_any_test.go
+++ b/optimizer/count_any_test.go
@@ -1,0 +1,166 @@
+package optimizer_test
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr"
+	. "github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/internal/testify/assert"
+	"github.com/expr-lang/expr/internal/testify/require"
+	"github.com/expr-lang/expr/optimizer"
+	"github.com/expr-lang/expr/parser"
+	"github.com/expr-lang/expr/vm"
+)
+
+func TestOptimize_count_any(t *testing.T) {
+	tree, err := parser.Parse(`count(items, .active) > 0`)
+	require.NoError(t, err)
+
+	err = optimizer.Optimize(&tree.Node, nil)
+	require.NoError(t, err)
+
+	expected := &BuiltinNode{
+		Name: "any",
+		Arguments: []Node{
+			&IdentifierNode{Value: "items"},
+			&PredicateNode{
+				Node: &MemberNode{
+					Node:     &PointerNode{},
+					Property: &StringNode{Value: "active"},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, Dump(expected), Dump(tree.Node))
+}
+
+func TestOptimize_count_any_gte_one(t *testing.T) {
+	tree, err := parser.Parse(`count(items, .valid) >= 1`)
+	require.NoError(t, err)
+
+	err = optimizer.Optimize(&tree.Node, nil)
+	require.NoError(t, err)
+
+	expected := &BuiltinNode{
+		Name: "any",
+		Arguments: []Node{
+			&IdentifierNode{Value: "items"},
+			&PredicateNode{
+				Node: &MemberNode{
+					Node:     &PointerNode{},
+					Property: &StringNode{Value: "valid"},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, Dump(expected), Dump(tree.Node))
+}
+
+func TestOptimize_count_any_correctness(t *testing.T) {
+	tests := []struct {
+		expr string
+		want bool
+	}{
+		// count > 0 → any
+		{`count(1..100, # == 1) > 0`, true},
+		{`count(1..100, # == 50) > 0`, true},
+		{`count(1..100, # == 100) > 0`, true},
+		{`count(1..100, # == 0) > 0`, false},
+
+		// count >= 1 → any
+		{`count(1..100, # % 10 == 0) >= 1`, true},
+		{`count(1..100, # > 100) >= 1`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			program, err := expr.Compile(tt.expr)
+			require.NoError(t, err)
+
+			output, err := expr.Run(program, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, output)
+		})
+	}
+}
+
+func TestOptimize_count_no_optimization(t *testing.T) {
+	// These should NOT be optimized
+	tests := []string{
+		`count(items, .active) > 1`,  // not > 0
+		`count(items, .active) >= 2`, // not >= 1
+		`count(items, .active) == 0`, // not optimized (none has overhead)
+		`count(items, .active) == 1`, // not == 0
+		`count(items, .active) < 1`,  // not optimized (none has overhead)
+		`count(items, .active) <= 0`, // not optimized (none has overhead)
+		`count(items, .active) != 0`, // different operator
+	}
+
+	for _, code := range tests {
+		t.Run(code, func(t *testing.T) {
+			tree, err := parser.Parse(code)
+			require.NoError(t, err)
+
+			err = optimizer.Optimize(&tree.Node, nil)
+			require.NoError(t, err)
+
+			// Should still be a BinaryNode (not optimized to any)
+			_, ok := tree.Node.(*BinaryNode)
+			assert.True(t, ok, "expected BinaryNode, got %T", tree.Node)
+		})
+	}
+}
+
+// Benchmarks for count > 0 → any
+func BenchmarkCountGtZero(b *testing.B) {
+	program, _ := expr.Compile(`count(1..1000, # == 1) > 0`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+func BenchmarkCountGtZeroLargeEarlyMatch(b *testing.B) {
+	program, _ := expr.Compile(`count(1..10000, # == 1) > 0`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+func BenchmarkCountGtZeroNoMatch(b *testing.B) {
+	program, _ := expr.Compile(`count(1..1000, # == 0) > 0`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+// Benchmarks for count >= 1 → any
+func BenchmarkCountGteOneEarlyMatch(b *testing.B) {
+	program, _ := expr.Compile(`count(1..1000, # == 1) >= 1`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+func BenchmarkCountGteOneNoMatch(b *testing.B) {
+	program, _ := expr.Compile(`count(1..1000, # == 0) >= 1`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}

--- a/optimizer/optimizer.go
+++ b/optimizer/optimizer.go
@@ -43,6 +43,7 @@ func Optimize(node *Node, config *conf.Config) error {
 	Walk(node, &sumRange{})
 	Walk(node, &sumArray{})
 	Walk(node, &sumMap{})
+	Walk(node, &countAny{})
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

When checking if a collection has at least one matching element, users commonly write `count(arr, pred) > 0` or `count(arr, pred) >= 1`. However, `count` iterates through the entire array even when a match is found early. The `any` builtin provides early termination. This optimization transforms matching `count` comparisons into `any` calls, providing nice performance improvements.

## Changes

Add `countAny` optimizer that transforms:

- `count(arr, pred) > 0` -> `any(arr, pred)`
- `count(arr, pred) >= 1` -> `any(arr, pred)`

Tests and benchmarks included. For benchmarks, run:

```bash
go test ./optimizer/... -bench='BenchmarkCount' -benchmem -run=^$ -count=10
```

Benchstat results:

```
cpu: Apple M1 Pro
                             │  master.out   │               fix.out                │
                             │    sec/op     │    sec/op     vs base                │
CountGtZero-8                  36.809µ ± 34%   1.878µ ± 11%  -94.90% (p=0.000 n=10)
CountGtZeroLargeEarlyMatch-8   371.08µ ± 15%   11.38µ ±  5%  -96.93% (p=0.000 n=10)
CountGtZeroNoMatch-8            36.88µ ±  7%   35.93µ ± 61%        ~ (p=0.247 n=10)
CountGteOneEarlyMatch-8        41.480µ ± 53%   1.911µ ± 22%  -95.39% (p=0.000 n=10)
CountGteOneNoMatch-8            36.44µ ±  6%   35.81µ ±  5%        ~ (p=0.289 n=10)
geomean                         59.75µ         8.792µ        -85.28%

                             │  master.out   │                fix.out                 │
                             │     B/op      │     B/op      vs base                  │
CountGtZero-8                  15.938Ki ± 0%   8.133Ki ± 0%  -48.97% (p=0.000 n=10)
CountGtZeroLargeEarlyMatch-8   158.25Ki ± 0%   80.13Ki ± 0%  -49.36% (p=0.000 n=10)
CountGtZeroNoMatch-8            15.94Ki ± 0%   15.94Ki ± 0%        ~ (p=1.000 n=10) ¹
CountGteOneEarlyMatch-8        15.938Ki ± 0%   8.133Ki ± 0%  -48.97% (p=0.000 n=10)
CountGteOneNoMatch-8            15.94Ki ± 0%   15.94Ki ± 0%        ~ (p=1.000 n=10) ¹
geomean                         25.22Ki        16.82Ki       -33.32%
¹ all samples are equal

                             │   master.out   │                fix.out                │
                             │   allocs/op    │  allocs/op   vs base                  │
CountGtZero-8                   1005.000 ± 0%    6.000 ± 0%  -99.40% (p=0.000 n=10)
CountGtZeroLargeEarlyMatch-8   10005.000 ± 0%    6.000 ± 0%  -99.94% (p=0.000 n=10)
CountGtZeroNoMatch-8              1.005k ± 0%   1.005k ± 0%        ~ (p=1.000 n=10) ¹
CountGteOneEarlyMatch-8         1005.000 ± 0%    6.000 ± 0%  -99.40% (p=0.000 n=10)
CountGteOneNoMatch-8              1.005k ± 0%   1.005k ± 0%        ~ (p=1.000 n=10) ¹
geomean                           1.591k         46.53       -97.08%
¹ all samples are equal
```

## Further comments

These patterns map directly to the existing `any` builtin which has early termination. Other thresholds like `count > 100` cannot be optimized because there's no equivalent builtin.

I also looked into optimising `== 0`, ` < 1` and `<= 0` with the `none` builtin. It showed regression in no-match scenarios which I guess comes from the extra `OpNot` instruction per iteration in `none` bytecode. Seemed like an optimisation not worth doing at this time.

A potential language enhancement could be adding an `atLeast(array, predicate, n)` builtin. So if `any` is "stop at 1st match" then `atLeast` would "stop at nth match". Basically the optimizer could then do:

- `count(arr, pred) > 100` -> `atLeast(arr, pred, 101)`
- `count(arr, pred) >= 50` -> `atLeast(arr, pred, 50)`

And while writing this I actually realised `any` could be represented as `atleast(arr, pred, 1)`. But let me know what you think @antonmedv!