### PR TITLE
perf(optimizer): add count threshold comparisons

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -187,6 +187,7 @@ type BuiltinNode struct {
 	Arguments []Node // Arguments of the builtin function.
 	Throws    bool   // If true then accessing a field or array index can throw an error. Used by optimizer.
 	Map       Node   // Used by optimizer to fold filter() and map() builtins.
+	Threshold *int   // Used by optimizer for count() early termination.
 }
 
 // PredicateNode represents a predicate.

--- a/optimizer/count_threshold.go
+++ b/optimizer/count_threshold.go
@@ -1,0 +1,54 @@
+package optimizer
+
+import (
+	. "github.com/expr-lang/expr/ast"
+)
+
+// countThreshold optimizes count comparisons by setting a threshold for early termination.
+// The threshold allows the count loop to exit early once enough matches are found.
+// Patterns:
+//   - count(arr, pred) > N  → threshold = N + 1 (exit proves > N is true)
+//   - count(arr, pred) >= N → threshold = N (exit proves >= N is true)
+//   - count(arr, pred) < N  → threshold = N (exit proves < N is false)
+//   - count(arr, pred) <= N → threshold = N + 1 (exit proves <= N is false)
+type countThreshold struct{}
+
+func (*countThreshold) Visit(node *Node) {
+	binary, ok := (*node).(*BinaryNode)
+	if !ok {
+		return
+	}
+
+	count, ok := binary.Left.(*BuiltinNode)
+	if !ok || count.Name != "count" || len(count.Arguments) != 2 {
+		return
+	}
+
+	integer, ok := binary.Right.(*IntegerNode)
+	if !ok || integer.Value < 0 {
+		return
+	}
+
+	var threshold int
+	switch binary.Operator {
+	case ">":
+		threshold = integer.Value + 1
+	case ">=":
+		threshold = integer.Value
+	case "<":
+		threshold = integer.Value
+	case "<=":
+		threshold = integer.Value + 1
+	default:
+		return
+	}
+
+	// Skip if threshold is 0 or 1 (handled by count_any optimizer)
+	if threshold <= 1 {
+		return
+	}
+
+	// Set threshold on the count node for early termination
+	// The original comparison remains unchanged
+	count.Threshold = &threshold
+}

--- a/optimizer/count_threshold_test.go
+++ b/optimizer/count_threshold_test.go
@@ -1,0 +1,278 @@
+package optimizer_test
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr"
+	. "github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/internal/testify/assert"
+	"github.com/expr-lang/expr/internal/testify/require"
+	"github.com/expr-lang/expr/optimizer"
+	"github.com/expr-lang/expr/parser"
+	"github.com/expr-lang/expr/vm"
+)
+
+func TestOptimize_count_threshold_gt(t *testing.T) {
+	tree, err := parser.Parse(`count(items, .active) > 100`)
+	require.NoError(t, err)
+
+	err = optimizer.Optimize(&tree.Node, nil)
+	require.NoError(t, err)
+
+	// Operator should remain >, but count should have threshold set
+	binary, ok := tree.Node.(*BinaryNode)
+	require.True(t, ok, "expected BinaryNode, got %T", tree.Node)
+	assert.Equal(t, ">", binary.Operator)
+
+	count, ok := binary.Left.(*BuiltinNode)
+	require.True(t, ok, "expected BuiltinNode, got %T", binary.Left)
+	assert.Equal(t, "count", count.Name)
+	require.NotNil(t, count.Threshold)
+	assert.Equal(t, 101, *count.Threshold) // threshold = N + 1 for > operator
+}
+
+func TestOptimize_count_threshold_gte(t *testing.T) {
+	tree, err := parser.Parse(`count(items, .active) >= 50`)
+	require.NoError(t, err)
+
+	err = optimizer.Optimize(&tree.Node, nil)
+	require.NoError(t, err)
+
+	// Operator should remain >=, but count should have threshold set
+	binary, ok := tree.Node.(*BinaryNode)
+	require.True(t, ok, "expected BinaryNode, got %T", tree.Node)
+	assert.Equal(t, ">=", binary.Operator)
+
+	count, ok := binary.Left.(*BuiltinNode)
+	require.True(t, ok, "expected BuiltinNode, got %T", binary.Left)
+	assert.Equal(t, "count", count.Name)
+	require.NotNil(t, count.Threshold)
+	assert.Equal(t, 50, *count.Threshold) // threshold = N for >= operator
+}
+
+func TestOptimize_count_threshold_lt(t *testing.T) {
+	tree, err := parser.Parse(`count(items, .active) < 100`)
+	require.NoError(t, err)
+
+	err = optimizer.Optimize(&tree.Node, nil)
+	require.NoError(t, err)
+
+	// Operator should remain <, but count should have threshold set
+	binary, ok := tree.Node.(*BinaryNode)
+	require.True(t, ok, "expected BinaryNode, got %T", tree.Node)
+	assert.Equal(t, "<", binary.Operator)
+
+	count, ok := binary.Left.(*BuiltinNode)
+	require.True(t, ok, "expected BuiltinNode, got %T", binary.Left)
+	assert.Equal(t, "count", count.Name)
+	require.NotNil(t, count.Threshold)
+	assert.Equal(t, 100, *count.Threshold) // threshold = N for < operator
+}
+
+func TestOptimize_count_threshold_lte(t *testing.T) {
+	tree, err := parser.Parse(`count(items, .active) <= 50`)
+	require.NoError(t, err)
+
+	err = optimizer.Optimize(&tree.Node, nil)
+	require.NoError(t, err)
+
+	// Operator should remain <=, but count should have threshold set
+	binary, ok := tree.Node.(*BinaryNode)
+	require.True(t, ok, "expected BinaryNode, got %T", tree.Node)
+	assert.Equal(t, "<=", binary.Operator)
+
+	count, ok := binary.Left.(*BuiltinNode)
+	require.True(t, ok, "expected BuiltinNode, got %T", binary.Left)
+	assert.Equal(t, "count", count.Name)
+	require.NotNil(t, count.Threshold)
+	assert.Equal(t, 51, *count.Threshold) // threshold = N + 1 for <= operator
+}
+
+func TestOptimize_count_threshold_correctness(t *testing.T) {
+	tests := []struct {
+		expr string
+		want bool
+	}{
+		// count > N (threshold = N + 1)
+		{`count(1..1000, # <= 100) > 50`, true},   // 100 matches > 50
+		{`count(1..1000, # <= 100) > 100`, false}, // 100 matches not > 100
+		{`count(1..1000, # <= 100) > 99`, true},   // 100 matches > 99
+		{`count(1..100, # > 0) > 50`, true},       // 100 matches > 50
+		{`count(1..100, # > 0) > 100`, false},     // 100 matches not > 100
+
+		// count >= N (threshold = N)
+		{`count(1..1000, # <= 100) >= 100`, true},  // 100 matches >= 100
+		{`count(1..1000, # <= 100) >= 101`, false}, // 100 matches not >= 101
+		{`count(1..100, # > 0) >= 50`, true},       // 100 matches >= 50
+		{`count(1..100, # > 0) >= 100`, true},      // 100 matches >= 100
+
+		// count < N (threshold = N)
+		{`count(1..1000, # <= 100) < 101`, true},  // 100 matches < 101
+		{`count(1..1000, # <= 100) < 100`, false}, // 100 matches not < 100
+		{`count(1..1000, # <= 100) < 50`, false},  // 100 matches not < 50
+		{`count(1..100, # > 0) < 101`, true},      // 100 matches < 101
+		{`count(1..100, # > 0) < 100`, false},     // 100 matches not < 100
+
+		// count <= N (threshold = N + 1)
+		{`count(1..1000, # <= 100) <= 100`, true},  // 100 matches <= 100
+		{`count(1..1000, # <= 100) <= 99`, false},  // 100 matches not <= 99
+		{`count(1..1000, # <= 100) <= 50`, false},  // 100 matches not <= 50
+		{`count(1..100, # > 0) <= 100`, true},      // 100 matches <= 100
+		{`count(1..100, # > 0) <= 99`, false},      // 100 matches not <= 99
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			program, err := expr.Compile(tt.expr)
+			require.NoError(t, err)
+
+			output, err := expr.Run(program, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, output)
+		})
+	}
+}
+
+func TestOptimize_count_threshold_no_optimization(t *testing.T) {
+	// These should NOT get a threshold (handled by count_any or not optimizable)
+	tests := []struct {
+		code      string
+		threshold bool
+	}{
+		{`count(items, .active) > 0`, false},   // handled by count_any
+		{`count(items, .active) >= 1`, false},  // handled by count_any
+		{`count(items, .active) < 1`, false},   // threshold = 1, skipped
+		{`count(items, .active) <= 0`, false},  // threshold = 1, skipped
+		{`count(items, .active) == 10`, false}, // not supported
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			tree, err := parser.Parse(tt.code)
+			require.NoError(t, err)
+
+			err = optimizer.Optimize(&tree.Node, nil)
+			require.NoError(t, err)
+
+			// Check if count has threshold set
+			var count *BuiltinNode
+			if binary, ok := tree.Node.(*BinaryNode); ok {
+				count, _ = binary.Left.(*BuiltinNode)
+			} else if builtin, ok := tree.Node.(*BuiltinNode); ok {
+				count = builtin
+			}
+
+			if count != nil && count.Name == "count" {
+				if tt.threshold {
+					assert.NotNil(t, count.Threshold, "expected threshold to be set")
+				} else {
+					assert.Nil(t, count.Threshold, "expected threshold to be nil")
+				}
+			}
+		})
+	}
+}
+
+// Benchmark: count > 100 with early match (element 101 matches early)
+func BenchmarkCountThresholdEarlyMatch(b *testing.B) {
+	// Array of 10000 elements, all match predicate, threshold is 101
+	// Should exit after ~101 iterations
+	program, _ := expr.Compile(`count(1..10000, # > 0) > 100`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+// Benchmark: count >= 50 with early match
+func BenchmarkCountThresholdGteEarlyMatch(b *testing.B) {
+	// All elements match, threshold is 50
+	// Should exit after ~50 iterations
+	program, _ := expr.Compile(`count(1..10000, # > 0) >= 50`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+// Benchmark: count > 100 with no early exit (not enough matches)
+func BenchmarkCountThresholdNoEarlyExit(b *testing.B) {
+	// Only 100 elements match (# <= 100), threshold is 101
+	// Must scan entire array
+	program, _ := expr.Compile(`count(1..10000, # <= 100) > 100`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+// Benchmark: Large threshold with early match
+func BenchmarkCountThresholdLargeEarlyMatch(b *testing.B) {
+	// All 10000 match, threshold is 1000
+	// Should exit after ~1000 iterations
+	program, _ := expr.Compile(`count(1..10000, # > 0) > 999`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+// Benchmark: count < N with early exit (result is false)
+func BenchmarkCountThresholdLtEarlyExit(b *testing.B) {
+	// All 10000 match, threshold is 100
+	// Should exit after ~100 iterations with result = false
+	program, _ := expr.Compile(`count(1..10000, # > 0) < 100`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+// Benchmark: count <= N with early exit (result is false)
+func BenchmarkCountThresholdLteEarlyExit(b *testing.B) {
+	// All 10000 match, threshold is 51
+	// Should exit after ~51 iterations with result = false
+	program, _ := expr.Compile(`count(1..10000, # > 0) <= 50`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+// Benchmark: count < N without early exit (result is true)
+func BenchmarkCountThresholdLtNoEarlyExit(b *testing.B) {
+	// Only 100 elements match (# <= 100), threshold is 200
+	// Must scan entire array, result = true
+	program, _ := expr.Compile(`count(1..10000, # <= 100) < 200`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}
+
+// Benchmark: count <= N without early exit (result is true)
+func BenchmarkCountThresholdLteNoEarlyExit(b *testing.B) {
+	// Only 100 elements match (# <= 100), threshold is 101
+	// Must scan entire array, result = true
+	program, _ := expr.Compile(`count(1..10000, # <= 100) <= 100`)
+	var out any
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		out, _ = vm.Run(program, nil)
+	}
+	_ = out
+}

--- a/optimizer/optimizer.go
+++ b/optimizer/optimizer.go
@@ -44,6 +44,7 @@ func Optimize(node *Node, config *conf.Config) error {
 	Walk(node, &sumArray{})
 	Walk(node, &sumMap{})
 	Walk(node, &countAny{})
+	Walk(node, &countThreshold{})
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

In #897 count comparisons like `count(users, .active) >= 1` were optimised by utilising the `any` builtin. Expressions like `count(users, .active) > 100` currently iterate through the entire array even when the 101st match is found early. For large arrays where the threshold is reached quickly, this wastes resources (both CPU and memory).

This optimization enables early termination: once the `count` reaches the required threshold, the loop exits immediately. This is the bytecode-level approach to optimizing count comparisons without introducing new language builtins (and bloat the stdlib in the process).

## Changes

There's now a new `Threshold` field in the `BuiltinNode` AST. This handles the communication between the two phases. The new optimizer `countThreshold` detects count comparison patterns and calculates the threshold:


- `count(arr, pred) > N`  -> `threshold = N + 1` (exit proves > N is true)
- `count(arr, pred) >= N` -> `threshold = N` (exit proves >= N is true)
- `count(arr, pred) < N` -> `threshold = N` (exit proves < N is false)
- `count(arr, pred) <= N` -> `threshold = N + 1` (exit proves <= N is false)

Modified the compiler's `count` builtin handler to emit early-termination bytecode when a threshold is set.

Benchmark run:

```bash
go test ./optimizer/... -bench='BenchmarkCountThreshold' -run=^$ -benchmem -count=10
```

Results against `master`:

```
cpu: Apple M1 Pro
                                │    old.txt    │               new.txt               │
                                │    sec/op     │   sec/op     vs base                │
CountThresholdEarlyMatch-8        393.34µ ±  2%   20.15µ ± 7%  -94.88% (p=0.000 n=10)
CountThresholdGteEarlyMatch-8     401.33µ ± 12%   17.28µ ± 2%  -95.70% (p=0.000 n=10)
CountThresholdNoEarlyExit-8        357.1µ ±  3%   361.2µ ± 2%   +1.15% (p=0.043 n=10)
CountThresholdLargeEarlyMatch-8   391.58µ ±  5%   83.22µ ± 3%  -78.75% (p=0.000 n=10)
CountThresholdLtEarlyExit-8       411.16µ ± 42%   19.80µ ± 1%  -95.18% (p=0.000 n=10)
CountThresholdLteEarlyExit-8      397.49µ ±  2%   17.24µ ± 3%  -95.66% (p=0.000 n=10)
CountThresholdLtNoEarlyExit-8      365.2µ ± 13%   363.1µ ± 1%        ~ (p=0.529 n=10)
CountThresholdLteNoEarlyExit-8     363.0µ ±  5%   361.3µ ± 1%        ~ (p=0.315 n=10)
geomean                            384.6µ         68.21µ       -82.26%

                                │    old.txt    │                new.txt                 │
                                │     B/op      │     B/op      vs base                  │
CountThresholdEarlyMatch-8        158.26Ki ± 0%   80.92Ki ± 0%  -48.87% (p=0.000 n=10)
CountThresholdGteEarlyMatch-8     158.26Ki ± 0%   80.52Ki ± 0%  -49.12% (p=0.000 n=10)
CountThresholdNoEarlyExit-8        158.3Ki ± 0%   158.3Ki ± 0%        ~ (p=1.000 n=10) ¹
CountThresholdLargeEarlyMatch-8    158.3Ki ± 0%   101.6Ki ± 0%  -35.81% (p=0.000 n=10)
CountThresholdLtEarlyExit-8       158.26Ki ± 0%   80.91Ki ± 0%  -48.88% (p=0.000 n=10)
CountThresholdLteEarlyExit-8      158.26Ki ± 0%   80.52Ki ± 0%  -49.12% (p=0.000 n=10)
CountThresholdLtNoEarlyExit-8      158.3Ki ± 0%   158.3Ki ± 0%        ~ (p=0.474 n=10)
CountThresholdLteNoEarlyExit-8     158.3Ki ± 0%   158.3Ki ± 0%        ~ (p=1.000 n=10)
geomean                            158.3Ki        106.9Ki       -32.43%
¹ all samples are equal

                                │    old.txt    │                new.txt                │
                                │   allocs/op   │  allocs/op   vs base                  │
CountThresholdEarlyMatch-8         10006.0 ± 0%    106.0 ± 0%  -98.94% (p=0.000 n=10)
CountThresholdGteEarlyMatch-8     10006.00 ± 0%    55.00 ± 0%  -99.45% (p=0.000 n=10)
CountThresholdNoEarlyExit-8         10.01k ± 0%   10.01k ± 0%        ~ (p=1.000 n=10) ¹
CountThresholdLargeEarlyMatch-8    10.006k ± 0%   2.751k ± 0%  -72.51% (p=0.000 n=10)
CountThresholdLtEarlyExit-8        10006.0 ± 0%    105.0 ± 0%  -98.95% (p=0.000 n=10)
CountThresholdLteEarlyExit-8      10006.00 ± 0%    56.00 ± 0%  -99.44% (p=0.000 n=10)
CountThresholdLtNoEarlyExit-8       10.01k ± 0%   10.01k ± 0%        ~ (p=1.000 n=10) ¹
CountThresholdLteNoEarlyExit-8      10.01k ± 0%   10.01k ± 0%        ~ (p=1.000 n=10) ¹
geomean                             10.01k         744.6       -92.56%
¹ all samples are equal
```

## Further comments

- This follows the same pattern as `BuiltinNode.Map`, which the `filterMap` optimizer uses to exchange information between the compiler and the optimizer phases.
- We add some bytecode overhead - essentially 4 extra opcodes when threshold is set.
- The `countAny` optimizer still remains in use for `> 0` and `>= 1` scenarios. It runs before this new `countThreshold` optimizer.
- The complexity was previously `O(n)` where _n_ equals the array length. With this it's `O(k)` where k is position of Nth matching element.

