### PR TITLE
fix(fuzz): skip time parsing errors

### DIFF
--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -47,6 +47,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`strings: negative Repeat count`),
 		regexp.MustCompile(`strings: illegal bytes to escape`),
 		regexp.MustCompile(`invalid date .*`),
+		regexp.MustCompile(`parsing time .*`),
 		regexp.MustCompile(`cannot parse .* as .*`),
 		regexp.MustCompile(`operator "in" not defined on .*`),
 		regexp.MustCompile(`cannot sum .*`),


### PR DESCRIPTION
Add `parsing time .*` pattern to skip list to handle Go `time.Parse` errors like "parsing time ... extra text ..." that are expected runtime errors, not bugs.

Relates to #900 