### PR TITLE
fix(vm): validate arg count before OpCall

### DIFF
--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -40,6 +40,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`reflect.Value.MapIndex: value of type .* is not assignable to type .*`),
 		regexp.MustCompile(`reflect: Call using .* as type .*`),
 		regexp.MustCompile(`reflect: Call with too few input arguments`),
+		regexp.MustCompile(`invalid number of arguments`),
 		regexp.MustCompile(`reflect: call of reflect.Value.Call on .* Value`),
 		regexp.MustCompile(`reflect: call of reflect.Value.Index on map Value`),
 		regexp.MustCompile(`reflect: call of reflect.Value.Len on .* Value`),

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -372,9 +372,18 @@ func (vm *VM) Run(program *Program, env any) (_ any, err error) {
 			}
 			fnType := fn.Type()
 			size := arg
-			in := make([]reflect.Value, size)
 			isVariadic := fnType.IsVariadic()
 			numIn := fnType.NumIn()
+			if isVariadic {
+				if size < numIn-1 {
+					panic(fmt.Sprintf("invalid number of arguments: expected at least %d, got %d", numIn-1, size))
+				}
+			} else {
+				if size != numIn {
+					panic(fmt.Sprintf("invalid number of arguments: expected %d, got %d", numIn, size))
+				}
+			}
+			in := make([]reflect.Value, size)
 			for i := int(size) - 1; i >= 0; i-- {
 				param := vm.pop()
 				if param == nil {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1491,3 +1491,22 @@ func TestVM_StackUnderflow(t *testing.T) {
 		})
 	}
 }
+
+func TestVM_OpCall_InvalidNumberOfArguments(t *testing.T) {
+	// This test ensures that calling a function with wrong number of arguments
+	// produces a clear error message instead of a panic.
+	// Regression test for clusterfuzz issue with expression:
+	// $env(''matches'  '? :now().UTC(g).d)//
+
+	env := map[string]any{
+		"ok": true,
+	}
+
+	code := `$env('' matches ' '? : now().UTC(g))`
+	program, err := expr.Compile(code, expr.Env(env))
+	require.NoError(t, err)
+
+	_, err = expr.Run(program, env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid number of arguments")
+}


### PR DESCRIPTION
## Motivation

See OSS-Fuzz finding #903. The expression `$env(''matches'  '? :now().UTC(g).d)//` caused:

> runtime error: index out of range [0] with length 0 (1:28)

The expression bypasses compile-time type checking due to `$env(...)` being treated as an unknown type. Also the ternary operator deferring evaluation. Then at runtime `UTC()` is called with an argument - even though it takes none. When the `OpCall` handler accesses `fnType.In(0)` without checking its length, an index out of bounds panic happens, although recovered by the VM.

## Changes

Added argument count validation in VM before attempting to call functions. Including a regression test.

## Further comments


Functions that return no values are already caught by the checker at compile time, so the `out[0]` access after `fn.Call()` remains safe.

Regression from #889.

Nice edge case catched by the fuzzer.