### PR TITLE
fix(fuzz): skip invalid location name errors

### DIFF
--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -33,6 +33,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`time: missing unit in duration`),
 		regexp.MustCompile(`time: unknown unit .* in duration`),
 		regexp.MustCompile(`unknown time zone`),
+		regexp.MustCompile(`invalid location name`),
 		regexp.MustCompile(`json: unsupported value`),
 		regexp.MustCompile(`unexpected end of JSON input`),
 		regexp.MustCompile(`memory budget exceeded`),


### PR DESCRIPTION
Relates to OSS-Fuzz finding described in #906:

```
time: invalid location name (1:1)
--
  | \| date('12719q5757884872@366','F','T[r.U/Kq.xw0e2..rp.wkeysrz--w.rp..wkew.r.w.r00z--Ξ-')//z--
  | \| ^
  | panic: errorf [recovered]
  | panic: errorf

```

Update ignore patterns accordingly, as this is not a valid finding.