### PR TITLE
fix(compiler): reduce empty array without init val

### DIFF
--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -150,6 +150,8 @@ func TestBuiltin(t *testing.T) {
 		{`reduce(1..9, # + #acc)`, 45},
 		{`reduce([.5, 1.5, 2.5], # + #acc, 0)`, 4.5},
 		{`reduce([], 5, 0)`, 0},
+		{`reduce(10..1, # + #acc, 100)`, 100},
+		{`reduce([], # + #acc, 42)`, 42},
 		{`concat(ArrayOfString, ArrayOfInt)`, []any{"foo", "bar", "baz", 1, 2, 3}},
 		{`concat(PtrArrayWithNil, [nil])`, []any{42, nil}},
 		{`flatten([["a", "b"], [1, 2]])`, []any{"a", "b", 1, 2}},

--- a/expr_test.go
+++ b/expr_test.go
@@ -1485,6 +1485,12 @@ func TestExpr_error(t *testing.T) {
  | ArrayOfAny[-7]
  | ..........^`,
 		},
+		{
+			`reduce(10..1, # + #acc)`,
+			`reduce of empty array with no initial value (1:1)
+ | reduce(10..1, # + #acc)
+ | ^`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -54,6 +54,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`operator "in" not defined on .*`),
 		regexp.MustCompile(`cannot sum .*`),
 		regexp.MustCompile(`index out of range: .* \(array length is .*\)`),
+		regexp.MustCompile(`reduce of empty array with no initial value`),
 		regexp.MustCompile(`cannot use <nil> as argument \(type .*\) to call .*`),
 		regexp.MustCompile(`illegal base64 data at input byte .*`),
 	}


### PR DESCRIPTION
## Motivation

Fuzzing discovered a panic in #908 on an unrelated change. The full run logs can be found [here](https://github.com/expr-lang/expr/actions/runs/21151236632/job/60827519215?pr=908) but the gist of it:

```
runtime error: index out of range [0] with length 0 (1:1)
 | reduce(9..0,357)
 | ^
panic: errorf [recovered]
	panic: errorf
```

This issue is triggered when `reduce` is called on an empty array without an initial value (e.g., `reduce(9..0, # + #acc)`). The compiler emits code that accessed the first element before checking if the array was empty.

## Changes

- Emit a bounds check before accessing the first array element when `reduce` has no initial value, throwing a descriptive error if the array is empty
- Add regression tests for the error case and for reduce with initial value on empty arrays
- Add the new error message to the fuzz test skip list

## Further comments

The optimizer correctly skips optimization for reversed ranges (like 10..1) and delegates to runtime. This fix ensures the runtime handles empty arrays gracefully instead of panicking.