### PR TITLE
fix(fuzz): reduce mem budget to prevent timeouts

### DIFF
--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
 )
 
 //go:embed fuzz_corpus.txt
@@ -76,7 +77,8 @@ func FuzzExpr(f *testing.F) {
 			t.Skipf("compile error: %s", err)
 		}
 
-		_, err = expr.Run(program, env)
+		v := vm.VM{MemoryBudget: 500000}
+		_, err = v.Run(program, env)
 		if err != nil {
 			for _, r := range skip {
 				if r.MatchString(err.Error()) {


### PR DESCRIPTION
Fixes OSS-Fuzz timeout #893  caused by expressions like "-817810..178" creating ~818K element arrays that exceeded the 60s timeout when passed to `fmt.Sprintf` for string formatting.

I had this as an alternative, basically to modify the fuzz test helper to skip formatting large input:

```go
func Func() expr.Option {
    return expr.Function("fn", func(params ...any) (any, error) {
        // Avoid expensive string formatting of large slices
        if len(params) == 1 {
            if arr, ok := params[0].([]int); ok && len(arr) > 10000 {
                return fmt.Sprintf("fn([%d elements])", len(arr)), nil
            }
        }
        return fmt.Sprintf("fn(%v)", params), nil
    })
}
```

But the mem budget modification felt like a cleaner option.