### PR TITLE
fix(fuzz): JSON number overflow errs in fromJSON

### DIFF
--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -283,6 +283,7 @@ func TestBuiltin_errors(t *testing.T) {
 		{`timezone(nil)`, "cannot use nil as argument (type string) to call timezone (1:10)"},
 		{`flatten([1, 2], [3, 4])`, "invalid number of arguments (expected 1, got 2)"},
 		{`flatten(1)`, "cannot flatten int"},
+		{`fromJSON("5e2482")`, "cannot unmarshal number"},
 	}
 	for _, test := range errorTests {
 		t.Run(test.input, func(t *testing.T) {

--- a/test/fuzz/fuzz_corpus.txt
+++ b/test/fuzz/fuzz_corpus.txt
@@ -19543,3 +19543,4 @@ values({"foo": ok})
 {"foo": score, "foo": array}.array
 {"foo": score, "foo": f32}
 {"foo": score, "foo": greet}
+fromJSON('5e2482')

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -36,6 +36,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`unknown time zone`),
 		regexp.MustCompile(`invalid location name`),
 		regexp.MustCompile(`json: unsupported value`),
+		regexp.MustCompile(`json: cannot unmarshal .* into Go value of type .*`),
 		regexp.MustCompile(`unexpected end of JSON input`),
 		regexp.MustCompile(`memory budget exceeded`),
 		regexp.MustCompile(`using interface \{} as type .*`),


### PR DESCRIPTION
Skip errors from `fromJSON` when parsing numbers with exponents too large for `float64` (e.g., `5e2482`). This is expected behavior from Go's `encoding/json package`, not a bug.

Relates to #914 