### PR TITLE
fix(builtin): bounds check to get()

### DIFF
--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -300,6 +300,21 @@ func TestBuiltin_errors(t *testing.T) {
 	}
 }
 
+// The get() builtin must return an error when called with
+// insufficient arguments at runtime, even if compile-time checks
+// are bypassed (regression test for OSS-Fuzz #479270603).
+func TestBuiltin_get_runtime_args_check(t *testing.T) {
+	code := `$env(''matches'i'?t:get().UTC())`
+	env := map[string]any{"t": 1}
+
+	program, err := expr.Compile(code, expr.Env(env))
+	require.NoError(t, err)
+
+	_, err = expr.Run(program, env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid number of arguments")
+}
+
 func TestBuiltin_types(t *testing.T) {
 	env := map[string]any{
 		"num":           42,

--- a/builtin/lib.go
+++ b/builtin/lib.go
@@ -564,6 +564,9 @@ func flatten(arg reflect.Value, depth int) ([]any, error) {
 }
 
 func get(params ...any) (out any, err error) {
+	if len(params) < 2 {
+		return nil, fmt.Errorf("invalid number of arguments (expected 2, got %d)", len(params))
+	}
 	from := params[0]
 	i := params[1]
 	v := reflect.ValueOf(from)


### PR DESCRIPTION
Validate argument count before accessing params slice in the `get()` function. This prevents a runtime panic when malformed input bypasses compile-time validation, as discovered by OSS-Fuzz.

Includes regression test for the specific fuzz case.

Relates to #917.