### PR TITLE
fix(fuzz): skip reflect err for variadic calls

### DIFF
--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -42,6 +42,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`using interface \{} as type .*`),
 		regexp.MustCompile(`reflect.Value.MapIndex: value of type .* is not assignable to type .*`),
 		regexp.MustCompile(`reflect: Call using .* as type .*`),
+		regexp.MustCompile(`reflect: cannot use .* as type .* in .*`),
 		regexp.MustCompile(`reflect: Call with too few input arguments`),
 		regexp.MustCompile(`invalid number of arguments`),
 		regexp.MustCompile(`reflect: call of reflect.Value.Call on .* Value`),


### PR DESCRIPTION
Skip pattern for the variadic function type mismatch error format ("reflect: cannot use X as type Y in Call"). Differs from the regular function error format that was already covered.

Fuzzing input:

```
score(    t,f64)/   v()             +  o| $env()//
```

and `score` is defined as `func(a int, x ...int)`. Here `f64` goes into the variadic part and yields the error.

Relates to #920.