### PR TITLE
fix(checker): detect $env() calls at compile time

### DIFF
--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -300,19 +300,13 @@ func TestBuiltin_errors(t *testing.T) {
 	}
 }
 
-// The get() builtin must return an error when called with
-// insufficient arguments at runtime, even if compile-time checks
-// are bypassed (regression test for OSS-Fuzz #479270603).
-func TestBuiltin_get_runtime_args_check(t *testing.T) {
+func TestBuiltin_env_not_callable(t *testing.T) {
 	code := `$env(''matches'i'?t:get().UTC())`
 	env := map[string]any{"t": 1}
 
-	program, err := expr.Compile(code, expr.Env(env))
-	require.NoError(t, err)
-
-	_, err = expr.Run(program, env)
+	_, err := expr.Compile(code, expr.Env(env))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid number of arguments")
+	assert.Contains(t, err.Error(), "is not callable")
 }
 
 func TestBuiltin_types(t *testing.T) {

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -651,6 +651,11 @@ func (v *Checker) callNode(node *ast.CallNode) Nature {
 		return *node.Nature()
 	}
 
+	// $env is not callable.
+	if id, ok := node.Callee.(*ast.IdentifierNode); ok && id.Value == "$env" {
+		return v.error(node, "%s is not callable", v.config.Env.String())
+	}
+
 	nt := v.visit(node.Callee)
 	if nt.IsUnknown(&v.config.NtCache) {
 		return Nature{}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -683,6 +683,30 @@ invalid operation: + (mismatched types int and bool) (1:6)
  | .....^
 `,
 		},
+		{
+			`$env()`,
+			`
+mock.Env is not callable (1:1)
+ | $env()
+ | ^
+`,
+		},
+		{
+			`$env(1)`,
+			`
+mock.Env is not callable (1:1)
+ | $env(1)
+ | ^
+`,
+		},
+		{
+			`$env(abs())`,
+			`
+mock.Env is not callable (1:1)
+ | $env(abs())
+ | ^
+`,
+		},
 	}
 
 	c := new(checker.Checker)


### PR DESCRIPTION
Previously, expressions like `$env(abs())` would compile without error and cause a runtime "stack underflow" panic. The checker now validates that $env cannot be used as a function callee, producing a clear error message like "map[string]interface {} is not callable".

Maybe a more long-term fix would be to add an `EnvNode` AST type. Now `$env` is used here and there as-is.

Relates to #922.