### PR TITLE
fix: wrap LoadLocation error in date() builtin

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -530,7 +530,7 @@ var Builtins = []*Function{
 				timeZone := args[2].(string)
 				tz, err := time.LoadLocation(timeZone)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("unknown time zone %s", timeZone)
 				}
 				t, err := time.ParseInLocation(layout, date, tz)
 				if err != nil {


### PR DESCRIPTION
When `date()` is called with an invalid timezone string like ".", time.LoadLocation can return raw OS-level errors such as "is a directory". Replace the raw error with a consistent "unknown time zone" message to improve error clarity and match the fuzz test's known-error skip patterns.

Relates to #930.