### PR TITLE
fix: reject unexported struct fields at runtime

### DIFF
--- a/builtin/lib.go
+++ b/builtin/lib.go
@@ -596,9 +596,10 @@ func get(params ...any) (out any, err error) {
 
 	case reflect.Struct:
 		fieldName := i.(string)
-		value := v.FieldByNameFunc(func(name string) bool {
-			field, _ := v.Type().FieldByName(name)
-			switch field.Tag.Get("expr") {
+		t := v.Type()
+		field, ok := t.FieldByNameFunc(func(name string) bool {
+			f, _ := t.FieldByName(name)
+			switch f.Tag.Get("expr") {
 			case "-":
 				return false
 			case fieldName:
@@ -607,8 +608,11 @@ func get(params ...any) (out any, err error) {
 				return name == fieldName
 			}
 		})
-		if value.IsValid() {
-			return value.Interface(), nil
+		if ok && field.IsExported() {
+			value := v.FieldByIndex(field.Index)
+			if value.IsValid() {
+				return value.Interface(), nil
+			}
 		}
 	}
 

--- a/test/issues/934/issue_test.go
+++ b/test/issues/934/issue_test.go
@@ -1,0 +1,53 @@
+package issue934
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/internal/testify/require"
+)
+
+type Env struct {
+	Exported
+	unexported
+}
+
+type Exported struct {
+	Str string
+	str string
+}
+
+type unexported struct {
+	Integer int
+	integer int
+}
+
+// TestIssue934 tests that accessing unexported fields on values whose type
+// is unknown at compile time (e.g., from a ternary with mixed types) yields
+// a descriptive error.
+//
+// OSS-Fuzz issue #486370271.
+func TestIssue934(t *testing.T) {
+	env := map[string]any{
+		"v": Env{},
+	}
+
+	// Accessing unexported fields like time.Time.loc
+        // should produce a proper error.
+	_, err := expr.Eval(`(true ? v : "string").str`, env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot fetch str")
+
+	// Exported field access should still work.
+	_, err = expr.Eval(`(true ? v : "string").Str`, env)
+	require.NoError(t, err)
+
+	// Access unexported field inherited from unexported embedded struct.
+	_, err = expr.Eval(`(true ? v : "string").integer`, env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot fetch integer")
+
+	// Access exported field inherited from unexported embedded struct should work.
+	_, err = expr.Eval(`(true ? v : "string").Integer`, env)
+	require.NoError(t, err)
+}

--- a/vm/runtime/runtime.go
+++ b/vm/runtime/runtime.go
@@ -90,7 +90,7 @@ func Fetch(from, i any) any {
 				return name == fieldName
 			}
 		})
-		if ok {
+		if ok && field.IsExported() {
 			value := v.FieldByIndex(field.Index)
 			if value.IsValid() {
 				fieldCache.Store(key, field.Index)


### PR DESCRIPTION
When the type checker cannot determine a concrete struct type at compile time (e.g. ternary with mixed types), field access falls through to dynamic `OpFetch` at runtime. The `Fetch` function in `vm/runtime` and the `get` function in `builtin/lib` used `FieldByNameFunc` which matched unexported fields, then called `Interface()` on the resulting `reflect.Value`, causing:

```
reflect.Value.Interface: cannot return value obtained from unexported field or method
```

Add `IsExported()` guards after `FieldByNameFunc` in both `Fetch()` and `get()` so unexported fields are never accessed via reflection. Error output from tests:

```
str error: cannot fetch str from main.Env (1:23)
 | (true ? v : "string").str
 | ......................^
integer error: cannot fetch integer from main.Env (1:23)
 | (true ? v : "string").integer
 | ......................^
```

This pattern is part of the allow list in the fuzzing harness, so the issue should clear out once merged.

Relates to #934.