### PR TITLE
fix(vm): handle non-comparable groupBy keys

### DIFF
--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -65,6 +65,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`sortBy order argument must be a string`),
 		regexp.MustCompile(`invalid order .*, expected asc or desc`),
 		regexp.MustCompile(`unknown order, use asc or desc`),
+		regexp.MustCompile(`cannot use .* as a key for groupBy: type is not comparable`),
 	}
 
 	env := NewEnv()

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -578,6 +578,9 @@ func (vm *VM) Run(program *Program, env any) (_ any, err error) {
 		case OpGroupBy:
 			scope := vm.currScope
 			key := vm.pop()
+			if key != nil && !reflect.TypeOf(key).Comparable() {
+				panic(fmt.Sprintf("cannot use %T as a key for groupBy: type is not comparable", key))
+			}
 			scope.Acc.(groupBy)[key] = append(scope.Acc.(groupBy)[key], scope.Item())
 
 		case OpSortBy:

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -488,6 +488,11 @@ func TestVM_GroupAndSortOperations(t *testing.T) {
 			},
 		},
 		{
+			name:        "group by with non-comparable key",
+			expr:        `groupBy([1, 2, 3], [#, # + 1])`, // predicate returns a slice, which is not comparable
+			expectError: "not comparable",
+		},
+		{
 			name:        "invalid sort order",
 			expr:        `sortBy([1, 2, 3], #, "invalid")`,
 			expectError: "unknown order",


### PR DESCRIPTION
Originally reported in #939 through OSS-Fuzz with this input:

```
fn( 6/ 2|fn( 0..3) | map( 2|fn($env) ) |groupBy(0..3) )
```

The `groupBy(0..3)` evaluates to `[]int{0, 1, 2, 3}` for every element. The `groupBy` results are stored in `map[any][]any` where the predicate result is used as the map key. And `[]int` is not comparable, thus the panic:

```
hash of unhashable type: []int
```

Check that the `groupBy` predicate result is comparable before using it as a map key.  Now it produces a clear error message instead of a non-descriptive panic:

```
cannot use []int as a key for groupBy: type is not comparable"
```

Updated the allow list in the fuzz test harness.