### PR TITLE
fix(vm): preserve int64/uint64 precision in arithmetic

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -805,15 +805,15 @@ func TestExpr(t *testing.T) {
 		},
 		{
 			`Uint64 + 0`,
-			0,
+			uint64(0),
 		},
 		{
 			`Uint64 + Int64`,
-			0,
+			uint64(0),
 		},
 		{
 			`Int32 + Int64`,
-			0,
+			int64(0),
 		},
 		{
 			`Float64 + 0`,

--- a/expr_test.go
+++ b/expr_test.go
@@ -805,11 +805,11 @@ func TestExpr(t *testing.T) {
 		},
 		{
 			`Uint64 + 0`,
-			uint64(0),
+			0,
 		},
 		{
 			`Uint64 + Int64`,
-			uint64(0),
+			0,
 		},
 		{
 			`Int32 + Int64`,

--- a/test/issues/804/issue_test.go
+++ b/test/issues/804/issue_test.go
@@ -1,0 +1,58 @@
+package issue_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/internal/testify/require"
+)
+
+// TestIssue804 verifies that arithmetic operations on int64 and uint64
+// operands preserve 64-bit precision instead of truncating to int
+// (which is 32-bit on 32-bit architectures).
+func TestIssue804(t *testing.T) {
+	env := map[string]any{
+		"a": int64(math.MaxInt32),
+		"b": int64(1),
+	}
+
+	// int64 + int64 must produce int64, not int.
+	out, err := expr.Eval("a + b", env)
+	require.NoError(t, err)
+	require.Equal(t, int64(math.MaxInt32)+1, out)
+
+	// int64 - int64
+	out, err = expr.Eval("a - b", env)
+	require.NoError(t, err)
+	require.Equal(t, int64(math.MaxInt32)-1, out)
+
+	// int64 * int64
+	out, err = expr.Eval("a * b", env)
+	require.NoError(t, err)
+	require.Equal(t, int64(math.MaxInt32), out)
+}
+
+func TestIssue804_uint64(t *testing.T) {
+	env := map[string]any{
+		"a": uint64(math.MaxUint32),
+		"b": uint64(1),
+	}
+
+	// uint64 + uint64 must produce uint64, not int.
+	out, err := expr.Eval("a + b", env)
+	require.NoError(t, err)
+	require.Equal(t, uint64(math.MaxUint32)+1, out)
+}
+
+func TestIssue804_mixed(t *testing.T) {
+	env := map[string]any{
+		"a": int32(100),
+		"b": int64(math.MaxInt32),
+	}
+
+	// int32 + int64 must produce int64.
+	out, err := expr.Eval("a + b", env)
+	require.NoError(t, err)
+	require.Equal(t, int64(100)+int64(math.MaxInt32), out)
+}

--- a/vm/runtime/helpers/main.go
+++ b/vm/runtime/helpers/main.go
@@ -72,6 +72,12 @@ func cases(op string, xs ...[]string) string {
 		echo(`switch y := b.(type) {`)
 		for _, b := range types {
 			t := "int"
+			if isInt64(a) || isInt64(b) {
+				t = "int64"
+			}
+			if isUint64(a) || isUint64(b) {
+				t = "uint64"
+			}
 			if isDuration(a) || isDuration(b) {
 				t = "time.Duration"
 			}
@@ -131,6 +137,14 @@ func arrayEqualCases(xs ...[]string) string {
 
 func isFloat(t string) bool {
 	return strings.HasPrefix(t, "float")
+}
+
+func isInt64(t string) bool {
+	return t == "int64"
+}
+
+func isUint64(t string) bool {
+	return t == "uint64"
 }
 
 func isDuration(t string) bool {
@@ -323,7 +337,7 @@ func Divide(a, b interface{}) float64 {
 	panic(fmt.Sprintf("invalid operation: %T / %T", a, b))
 }
 
-func Modulo(a, b interface{}) int {
+func Modulo(a, b interface{}) interface{} {
 	switch x := a.(type) {
 	{{ cases_int_only "%" }}
 	}

--- a/vm/runtime/helpers/main.go
+++ b/vm/runtime/helpers/main.go
@@ -72,10 +72,10 @@ func cases(op string, xs ...[]string) string {
 		echo(`switch y := b.(type) {`)
 		for _, b := range types {
 			t := "int"
-			if isInt64(a) || isInt64(b) {
+			if (isInt64(a) || isInt64(b)) && isSigned(a) && isSigned(b) {
 				t = "int64"
 			}
-			if isUint64(a) || isUint64(b) {
+			if (isUint64(a) || isUint64(b)) && isUnsigned(a) && isUnsigned(b) {
 				t = "uint64"
 			}
 			if isDuration(a) || isDuration(b) {
@@ -145,6 +145,14 @@ func isInt64(t string) bool {
 
 func isUint64(t string) bool {
 	return t == "uint64"
+}
+
+func isSigned(t string) bool {
+	return t == "int" || t == "int8" || t == "int16" || t == "int32" || t == "int64"
+}
+
+func isUnsigned(t string) bool {
+	return t == "uint" || t == "uint8" || t == "uint16" || t == "uint32" || t == "uint64"
 }
 
 func isDuration(t string) bool {

--- a/vm/runtime/helpers[generated].go
+++ b/vm/runtime/helpers[generated].go
@@ -31,7 +31,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int64(x) == int64(y)
+			return int(x) == int(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -58,7 +58,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int64(x) == int64(y)
+			return int(x) == int(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -85,7 +85,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int64(x) == int64(y)
+			return int(x) == int(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -112,7 +112,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int64(x) == int64(y)
+			return int(x) == int(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -131,15 +131,15 @@ func Equal(a, b interface{}) bool {
 		case uint64:
 			return uint64(x) == uint64(y)
 		case int:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int8:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int16:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int32:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int64:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -156,7 +156,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -183,7 +183,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -210,7 +210,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -237,7 +237,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -256,15 +256,15 @@ func Equal(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) == int64(y)
+			return int(x) == int(y)
 		case uint8:
-			return int64(x) == int64(y)
+			return int(x) == int(y)
 		case uint16:
-			return int64(x) == int64(y)
+			return int(x) == int(y)
 		case uint32:
-			return int64(x) == int64(y)
+			return int(x) == int(y)
 		case uint64:
-			return uint64(x) == uint64(y)
+			return int(x) == int(y)
 		case int:
 			return int64(x) == int64(y)
 		case int8:
@@ -722,7 +722,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int64(x) < int64(y)
+			return int(x) < int(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -749,7 +749,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int64(x) < int64(y)
+			return int(x) < int(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -776,7 +776,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int64(x) < int64(y)
+			return int(x) < int(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -803,7 +803,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int64(x) < int64(y)
+			return int(x) < int(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -822,15 +822,15 @@ func Less(a, b interface{}) bool {
 		case uint64:
 			return uint64(x) < uint64(y)
 		case int:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int8:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int16:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int32:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int64:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -847,7 +847,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -874,7 +874,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -901,7 +901,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -928,7 +928,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -947,15 +947,15 @@ func Less(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) < int64(y)
+			return int(x) < int(y)
 		case uint8:
-			return int64(x) < int64(y)
+			return int(x) < int(y)
 		case uint16:
-			return int64(x) < int64(y)
+			return int(x) < int(y)
 		case uint32:
-			return int64(x) < int64(y)
+			return int(x) < int(y)
 		case uint64:
-			return uint64(x) < uint64(y)
+			return int(x) < int(y)
 		case int:
 			return int64(x) < int64(y)
 		case int8:
@@ -1067,7 +1067,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int64(x) > int64(y)
+			return int(x) > int(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1094,7 +1094,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int64(x) > int64(y)
+			return int(x) > int(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1121,7 +1121,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int64(x) > int64(y)
+			return int(x) > int(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1148,7 +1148,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int64(x) > int64(y)
+			return int(x) > int(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1167,15 +1167,15 @@ func More(a, b interface{}) bool {
 		case uint64:
 			return uint64(x) > uint64(y)
 		case int:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int8:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int16:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int32:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int64:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1192,7 +1192,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1219,7 +1219,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1246,7 +1246,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1273,7 +1273,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1292,15 +1292,15 @@ func More(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) > int64(y)
+			return int(x) > int(y)
 		case uint8:
-			return int64(x) > int64(y)
+			return int(x) > int(y)
 		case uint16:
-			return int64(x) > int64(y)
+			return int(x) > int(y)
 		case uint32:
-			return int64(x) > int64(y)
+			return int(x) > int(y)
 		case uint64:
-			return uint64(x) > uint64(y)
+			return int(x) > int(y)
 		case int:
 			return int64(x) > int64(y)
 		case int8:
@@ -1412,7 +1412,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int64(x) <= int64(y)
+			return int(x) <= int(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1439,7 +1439,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int64(x) <= int64(y)
+			return int(x) <= int(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1466,7 +1466,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int64(x) <= int64(y)
+			return int(x) <= int(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1493,7 +1493,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int64(x) <= int64(y)
+			return int(x) <= int(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1512,15 +1512,15 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint64:
 			return uint64(x) <= uint64(y)
 		case int:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int8:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int16:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int32:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int64:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1537,7 +1537,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1564,7 +1564,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1591,7 +1591,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1618,7 +1618,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1637,15 +1637,15 @@ func LessOrEqual(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) <= int64(y)
+			return int(x) <= int(y)
 		case uint8:
-			return int64(x) <= int64(y)
+			return int(x) <= int(y)
 		case uint16:
-			return int64(x) <= int64(y)
+			return int(x) <= int(y)
 		case uint32:
-			return int64(x) <= int64(y)
+			return int(x) <= int(y)
 		case uint64:
-			return uint64(x) <= uint64(y)
+			return int(x) <= int(y)
 		case int:
 			return int64(x) <= int64(y)
 		case int8:
@@ -1757,7 +1757,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int64(x) >= int64(y)
+			return int(x) >= int(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1784,7 +1784,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int64(x) >= int64(y)
+			return int(x) >= int(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1811,7 +1811,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int64(x) >= int64(y)
+			return int(x) >= int(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1838,7 +1838,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int64(x) >= int64(y)
+			return int(x) >= int(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1857,15 +1857,15 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint64:
 			return uint64(x) >= uint64(y)
 		case int:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int8:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int16:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int32:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int64:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1882,7 +1882,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1909,7 +1909,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1936,7 +1936,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1963,7 +1963,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1982,15 +1982,15 @@ func MoreOrEqual(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) >= int64(y)
+			return int(x) >= int(y)
 		case uint8:
-			return int64(x) >= int64(y)
+			return int(x) >= int(y)
 		case uint16:
-			return int64(x) >= int64(y)
+			return int(x) >= int(y)
 		case uint32:
-			return int64(x) >= int64(y)
+			return int(x) >= int(y)
 		case uint64:
-			return uint64(x) >= uint64(y)
+			return int(x) >= int(y)
 		case int:
 			return int64(x) >= int64(y)
 		case int8:
@@ -2102,7 +2102,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int64(x) + int64(y)
+			return int(x) + int(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2129,7 +2129,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int64(x) + int64(y)
+			return int(x) + int(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2156,7 +2156,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int64(x) + int64(y)
+			return int(x) + int(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2183,7 +2183,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int64(x) + int64(y)
+			return int(x) + int(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2202,15 +2202,15 @@ func Add(a, b interface{}) interface{} {
 		case uint64:
 			return uint64(x) + uint64(y)
 		case int:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int8:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int16:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int32:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int64:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2227,7 +2227,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2254,7 +2254,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2281,7 +2281,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2308,7 +2308,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2327,15 +2327,15 @@ func Add(a, b interface{}) interface{} {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) + int64(y)
+			return int(x) + int(y)
 		case uint8:
-			return int64(x) + int64(y)
+			return int(x) + int(y)
 		case uint16:
-			return int64(x) + int64(y)
+			return int(x) + int(y)
 		case uint32:
-			return int64(x) + int64(y)
+			return int(x) + int(y)
 		case uint64:
-			return uint64(x) + uint64(y)
+			return int(x) + int(y)
 		case int:
 			return int64(x) + int64(y)
 		case int8:
@@ -2449,7 +2449,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int64(x) - int64(y)
+			return int(x) - int(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2476,7 +2476,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int64(x) - int64(y)
+			return int(x) - int(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2503,7 +2503,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int64(x) - int64(y)
+			return int(x) - int(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2530,7 +2530,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int64(x) - int64(y)
+			return int(x) - int(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2549,15 +2549,15 @@ func Subtract(a, b interface{}) interface{} {
 		case uint64:
 			return uint64(x) - uint64(y)
 		case int:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int8:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int16:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int32:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int64:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2574,7 +2574,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2601,7 +2601,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2628,7 +2628,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2655,7 +2655,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2674,15 +2674,15 @@ func Subtract(a, b interface{}) interface{} {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) - int64(y)
+			return int(x) - int(y)
 		case uint8:
-			return int64(x) - int64(y)
+			return int(x) - int(y)
 		case uint16:
-			return int64(x) - int64(y)
+			return int(x) - int(y)
 		case uint32:
-			return int64(x) - int64(y)
+			return int(x) - int(y)
 		case uint64:
-			return uint64(x) - uint64(y)
+			return int(x) - int(y)
 		case int:
 			return int64(x) - int64(y)
 		case int8:
@@ -2791,7 +2791,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int64(x) * int64(y)
+			return int(x) * int(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2820,7 +2820,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int64(x) * int64(y)
+			return int(x) * int(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2849,7 +2849,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int64(x) * int64(y)
+			return int(x) * int(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2878,7 +2878,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int64(x) * int64(y)
+			return int(x) * int(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2899,15 +2899,15 @@ func Multiply(a, b interface{}) interface{} {
 		case uint64:
 			return uint64(x) * uint64(y)
 		case int:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int8:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int16:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int32:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int64:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2926,7 +2926,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2955,7 +2955,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2984,7 +2984,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -3013,7 +3013,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -3034,15 +3034,15 @@ func Multiply(a, b interface{}) interface{} {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) * int64(y)
+			return int(x) * int(y)
 		case uint8:
-			return int64(x) * int64(y)
+			return int(x) * int(y)
 		case uint16:
-			return int64(x) * int64(y)
+			return int(x) * int(y)
 		case uint32:
-			return int64(x) * int64(y)
+			return int(x) * int(y)
 		case uint64:
-			return uint64(x) * uint64(y)
+			return int(x) * int(y)
 		case int:
 			return int64(x) * int64(y)
 		case int8:
@@ -3504,7 +3504,7 @@ func Modulo(a, b interface{}) interface{} {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int64(x) % int64(y)
+			return int(x) % int(y)
 		}
 	case uint8:
 		switch y := b.(type) {
@@ -3527,7 +3527,7 @@ func Modulo(a, b interface{}) interface{} {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int64(x) % int64(y)
+			return int(x) % int(y)
 		}
 	case uint16:
 		switch y := b.(type) {
@@ -3550,7 +3550,7 @@ func Modulo(a, b interface{}) interface{} {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int64(x) % int64(y)
+			return int(x) % int(y)
 		}
 	case uint32:
 		switch y := b.(type) {
@@ -3573,7 +3573,7 @@ func Modulo(a, b interface{}) interface{} {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int64(x) % int64(y)
+			return int(x) % int(y)
 		}
 	case uint64:
 		switch y := b.(type) {
@@ -3588,15 +3588,15 @@ func Modulo(a, b interface{}) interface{} {
 		case uint64:
 			return uint64(x) % uint64(y)
 		case int:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int8:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int16:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int32:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int64:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		}
 	case int:
 		switch y := b.(type) {
@@ -3609,7 +3609,7 @@ func Modulo(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3632,7 +3632,7 @@ func Modulo(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3655,7 +3655,7 @@ func Modulo(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3678,7 +3678,7 @@ func Modulo(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3693,15 +3693,15 @@ func Modulo(a, b interface{}) interface{} {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int64(x) % int64(y)
+			return int(x) % int(y)
 		case uint8:
-			return int64(x) % int64(y)
+			return int(x) % int(y)
 		case uint16:
-			return int64(x) % int64(y)
+			return int(x) % int(y)
 		case uint32:
-			return int64(x) % int64(y)
+			return int(x) % int(y)
 		case uint64:
-			return uint64(x) % uint64(y)
+			return int(x) % int(y)
 		case int:
 			return int64(x) % int64(y)
 		case int8:

--- a/vm/runtime/helpers[generated].go
+++ b/vm/runtime/helpers[generated].go
@@ -21,7 +21,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -31,7 +31,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -48,7 +48,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -58,7 +58,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -75,7 +75,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -85,7 +85,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -102,7 +102,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -112,7 +112,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -121,25 +121,25 @@ func Equal(a, b interface{}) bool {
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case uint8:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case uint16:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case uint32:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int8:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int16:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int32:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -156,7 +156,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -166,7 +166,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -183,7 +183,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -193,7 +193,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -210,7 +210,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -220,7 +220,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -237,7 +237,7 @@ func Equal(a, b interface{}) bool {
 		case uint32:
 			return int(x) == int(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
 			return int(x) == int(y)
 		case int8:
@@ -247,7 +247,7 @@ func Equal(a, b interface{}) bool {
 		case int32:
 			return int(x) == int(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -256,25 +256,25 @@ func Equal(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case uint8:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case uint16:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case uint32:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case uint64:
-			return int(x) == int(y)
+			return uint64(x) == uint64(y)
 		case int:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case int8:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case int16:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case int32:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case int64:
-			return int(x) == int(y)
+			return int64(x) == int64(y)
 		case float32:
 			return float64(x) == float64(y)
 		case float64:
@@ -712,7 +712,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -722,7 +722,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -739,7 +739,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -749,7 +749,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -766,7 +766,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -776,7 +776,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -793,7 +793,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -803,7 +803,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -812,25 +812,25 @@ func Less(a, b interface{}) bool {
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case uint8:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case uint16:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case uint32:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int8:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int16:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int32:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -847,7 +847,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -857,7 +857,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -874,7 +874,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -884,7 +884,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -901,7 +901,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -911,7 +911,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -928,7 +928,7 @@ func Less(a, b interface{}) bool {
 		case uint32:
 			return int(x) < int(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
 			return int(x) < int(y)
 		case int8:
@@ -938,7 +938,7 @@ func Less(a, b interface{}) bool {
 		case int32:
 			return int(x) < int(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -947,25 +947,25 @@ func Less(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case uint8:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case uint16:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case uint32:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case uint64:
-			return int(x) < int(y)
+			return uint64(x) < uint64(y)
 		case int:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case int8:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case int16:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case int32:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case int64:
-			return int(x) < int(y)
+			return int64(x) < int64(y)
 		case float32:
 			return float64(x) < float64(y)
 		case float64:
@@ -1057,7 +1057,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1067,7 +1067,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1084,7 +1084,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1094,7 +1094,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1111,7 +1111,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1121,7 +1121,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1138,7 +1138,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1148,7 +1148,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1157,25 +1157,25 @@ func More(a, b interface{}) bool {
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case uint8:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case uint16:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case uint32:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int8:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int16:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int32:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1192,7 +1192,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1202,7 +1202,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1219,7 +1219,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1229,7 +1229,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1246,7 +1246,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1256,7 +1256,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1273,7 +1273,7 @@ func More(a, b interface{}) bool {
 		case uint32:
 			return int(x) > int(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
 			return int(x) > int(y)
 		case int8:
@@ -1283,7 +1283,7 @@ func More(a, b interface{}) bool {
 		case int32:
 			return int(x) > int(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1292,25 +1292,25 @@ func More(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case uint8:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case uint16:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case uint32:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case uint64:
-			return int(x) > int(y)
+			return uint64(x) > uint64(y)
 		case int:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case int8:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case int16:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case int32:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case int64:
-			return int(x) > int(y)
+			return int64(x) > int64(y)
 		case float32:
 			return float64(x) > float64(y)
 		case float64:
@@ -1402,7 +1402,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1412,7 +1412,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1429,7 +1429,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1439,7 +1439,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1456,7 +1456,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1466,7 +1466,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1483,7 +1483,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1493,7 +1493,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1502,25 +1502,25 @@ func LessOrEqual(a, b interface{}) bool {
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case uint8:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case uint16:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case uint32:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int8:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int16:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int32:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1537,7 +1537,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1547,7 +1547,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1564,7 +1564,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1574,7 +1574,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1591,7 +1591,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1601,7 +1601,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1618,7 +1618,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) <= int(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
 			return int(x) <= int(y)
 		case int8:
@@ -1628,7 +1628,7 @@ func LessOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) <= int(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1637,25 +1637,25 @@ func LessOrEqual(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case uint8:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case uint16:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case uint32:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case uint64:
-			return int(x) <= int(y)
+			return uint64(x) <= uint64(y)
 		case int:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case int8:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case int16:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case int32:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case int64:
-			return int(x) <= int(y)
+			return int64(x) <= int64(y)
 		case float32:
 			return float64(x) <= float64(y)
 		case float64:
@@ -1747,7 +1747,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1757,7 +1757,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1774,7 +1774,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1784,7 +1784,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1801,7 +1801,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1811,7 +1811,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1828,7 +1828,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1838,7 +1838,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1847,25 +1847,25 @@ func MoreOrEqual(a, b interface{}) bool {
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case uint8:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case uint16:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case uint32:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int8:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int16:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int32:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1882,7 +1882,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1892,7 +1892,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1909,7 +1909,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1919,7 +1919,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1936,7 +1936,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1946,7 +1946,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1963,7 +1963,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case uint32:
 			return int(x) >= int(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
 			return int(x) >= int(y)
 		case int8:
@@ -1973,7 +1973,7 @@ func MoreOrEqual(a, b interface{}) bool {
 		case int32:
 			return int(x) >= int(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -1982,25 +1982,25 @@ func MoreOrEqual(a, b interface{}) bool {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case uint8:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case uint16:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case uint32:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case uint64:
-			return int(x) >= int(y)
+			return uint64(x) >= uint64(y)
 		case int:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case int8:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case int16:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case int32:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case int64:
-			return int(x) >= int(y)
+			return int64(x) >= int64(y)
 		case float32:
 			return float64(x) >= float64(y)
 		case float64:
@@ -2092,7 +2092,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2102,7 +2102,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2119,7 +2119,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2129,7 +2129,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2146,7 +2146,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2156,7 +2156,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2173,7 +2173,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2183,7 +2183,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2192,25 +2192,25 @@ func Add(a, b interface{}) interface{} {
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case uint8:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case uint16:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case uint32:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int8:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int16:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int32:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2227,7 +2227,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2237,7 +2237,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2254,7 +2254,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2264,7 +2264,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2281,7 +2281,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2291,7 +2291,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2308,7 +2308,7 @@ func Add(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) + int(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
 			return int(x) + int(y)
 		case int8:
@@ -2318,7 +2318,7 @@ func Add(a, b interface{}) interface{} {
 		case int32:
 			return int(x) + int(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2327,25 +2327,25 @@ func Add(a, b interface{}) interface{} {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case uint8:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case uint16:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case uint32:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case uint64:
-			return int(x) + int(y)
+			return uint64(x) + uint64(y)
 		case int:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case int8:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case int16:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case int32:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case int64:
-			return int(x) + int(y)
+			return int64(x) + int64(y)
 		case float32:
 			return float64(x) + float64(y)
 		case float64:
@@ -2439,7 +2439,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2449,7 +2449,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2466,7 +2466,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2476,7 +2476,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2493,7 +2493,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2503,7 +2503,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2520,7 +2520,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2530,7 +2530,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2539,25 +2539,25 @@ func Subtract(a, b interface{}) interface{} {
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case uint8:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case uint16:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case uint32:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int8:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int16:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int32:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2574,7 +2574,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2584,7 +2584,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2601,7 +2601,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2611,7 +2611,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2628,7 +2628,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2638,7 +2638,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2655,7 +2655,7 @@ func Subtract(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) - int(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
 			return int(x) - int(y)
 		case int8:
@@ -2665,7 +2665,7 @@ func Subtract(a, b interface{}) interface{} {
 		case int32:
 			return int(x) - int(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2674,25 +2674,25 @@ func Subtract(a, b interface{}) interface{} {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case uint8:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case uint16:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case uint32:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case uint64:
-			return int(x) - int(y)
+			return uint64(x) - uint64(y)
 		case int:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case int8:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case int16:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case int32:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case int64:
-			return int(x) - int(y)
+			return int64(x) - int64(y)
 		case float32:
 			return float64(x) - float64(y)
 		case float64:
@@ -2781,7 +2781,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2791,7 +2791,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2810,7 +2810,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2820,7 +2820,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2839,7 +2839,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2849,7 +2849,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2868,7 +2868,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2878,7 +2878,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2889,25 +2889,25 @@ func Multiply(a, b interface{}) interface{} {
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case uint8:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case uint16:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case uint32:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int8:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int16:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int32:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2926,7 +2926,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2936,7 +2936,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2955,7 +2955,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2965,7 +2965,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -2984,7 +2984,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -2994,7 +2994,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -3013,7 +3013,7 @@ func Multiply(a, b interface{}) interface{} {
 		case uint32:
 			return int(x) * int(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
 			return int(x) * int(y)
 		case int8:
@@ -3023,7 +3023,7 @@ func Multiply(a, b interface{}) interface{} {
 		case int32:
 			return int(x) * int(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -3034,25 +3034,25 @@ func Multiply(a, b interface{}) interface{} {
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case uint8:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case uint16:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case uint32:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case uint64:
-			return int(x) * int(y)
+			return uint64(x) * uint64(y)
 		case int:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case int8:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case int16:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case int32:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case int64:
-			return int(x) * int(y)
+			return int64(x) * int64(y)
 		case float32:
 			return float64(x) * float64(y)
 		case float64:
@@ -3481,7 +3481,7 @@ func Divide(a, b interface{}) float64 {
 	panic(fmt.Sprintf("invalid operation: %T / %T", a, b))
 }
 
-func Modulo(a, b interface{}) int {
+func Modulo(a, b interface{}) interface{} {
 	switch x := a.(type) {
 	case uint:
 		switch y := b.(type) {
@@ -3494,7 +3494,7 @@ func Modulo(a, b interface{}) int {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3504,7 +3504,7 @@ func Modulo(a, b interface{}) int {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	case uint8:
 		switch y := b.(type) {
@@ -3517,7 +3517,7 @@ func Modulo(a, b interface{}) int {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3527,7 +3527,7 @@ func Modulo(a, b interface{}) int {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	case uint16:
 		switch y := b.(type) {
@@ -3540,7 +3540,7 @@ func Modulo(a, b interface{}) int {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3550,7 +3550,7 @@ func Modulo(a, b interface{}) int {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	case uint32:
 		switch y := b.(type) {
@@ -3563,7 +3563,7 @@ func Modulo(a, b interface{}) int {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3573,30 +3573,30 @@ func Modulo(a, b interface{}) int {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	case uint64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case uint8:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case uint16:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case uint32:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int8:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int16:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int32:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		}
 	case int:
 		switch y := b.(type) {
@@ -3609,7 +3609,7 @@ func Modulo(a, b interface{}) int {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3619,7 +3619,7 @@ func Modulo(a, b interface{}) int {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	case int8:
 		switch y := b.(type) {
@@ -3632,7 +3632,7 @@ func Modulo(a, b interface{}) int {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3642,7 +3642,7 @@ func Modulo(a, b interface{}) int {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	case int16:
 		switch y := b.(type) {
@@ -3655,7 +3655,7 @@ func Modulo(a, b interface{}) int {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3665,7 +3665,7 @@ func Modulo(a, b interface{}) int {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	case int32:
 		switch y := b.(type) {
@@ -3678,7 +3678,7 @@ func Modulo(a, b interface{}) int {
 		case uint32:
 			return int(x) % int(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
 			return int(x) % int(y)
 		case int8:
@@ -3688,30 +3688,30 @@ func Modulo(a, b interface{}) int {
 		case int32:
 			return int(x) % int(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	case int64:
 		switch y := b.(type) {
 		case uint:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		case uint8:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		case uint16:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		case uint32:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		case uint64:
-			return int(x) % int(y)
+			return uint64(x) % uint64(y)
 		case int:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		case int8:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		case int16:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		case int32:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		case int64:
-			return int(x) % int(y)
+			return int64(x) % int64(y)
 		}
 	}
 	panic(fmt.Sprintf("invalid operation: %T %% %T", a, b))


### PR DESCRIPTION
Arithmetic between two `int64` values (or two `uint64` values) goes through `int`, which truncates on 32-bit platforms. The generated runtime helpers had no specialization for 64-bit types.

The code generator now emits `int64` cases when both operands are signed and at least one is `int64`, and `uint64` when both are unsigned and at least one is `uint64`. Mixed signed/unsigned stays as `int`.

Fixes #804