### PR TITLE
fix(compiler): pop stale bool from stack in emitLoopBackwards

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1213,12 +1213,14 @@ func (c *compiler) emitLoopBackwards(body func()) {
 	c.emit(OpInt, 0)
 	c.emit(OpMoreOrEqual)
 	end := c.emit(OpJumpIfFalse, placeholder)
+	c.emit(OpPop)
 
 	body()
 
 	c.emit(OpDecrementIndex)
 	c.emit(OpJumpBackward, c.calcBackwardJump(begin))
 	c.patchJump(end)
+	c.emit(OpPop)
 }
 
 func (c *compiler) PredicateNode(node *ast.PredicateNode) {

--- a/expr_test.go
+++ b/expr_test.go
@@ -1276,6 +1276,22 @@ func TestExpr(t *testing.T) {
 			7,
 		},
 		{
+			`{"r": findLast([1, 2, 3, 4, 5], # > 3)}`,
+			map[string]any{"r": 5},
+		},
+		{
+			`{"r": findLastIndex([1, 2, 3, 4, 5], # > 3)}`,
+			map[string]any{"r": 4},
+		},
+		{
+			`{"r": findLast([1, 2, 3], # > 10)}`,
+			map[string]any{"r": nil},
+		},
+		{
+			`{"a": findLast([1, 2, 3], # > 1), "b": findLastIndex([4, 5, 6], # > 4)}`,
+			map[string]any{"a": 3, "b": 2},
+		},
+		{
 			`filter(1..9, # % 2 == 0)[-1]`,
 			8,
 		},


### PR DESCRIPTION
Fixes #950

`findLast` and `findLastIndex` crash with `interface conversion: interface {} is bool, not string` when used inside map literal expressions.

**Failing scenario:**
```go
expr.Eval(`{"r": findLast([1, 2, 3, 4, 5], # > 3)}`, nil)
// runtime error: interface {} is bool, not string
```

The forward-iterating equivalents (`find`, `findIndex`) work fine in the same position.

**Root cause:**
`emitLoopBackwards` uses `OpMoreOrEqual` + `OpJumpIfFalse` to check the loop condition but never pops the comparison result. The stale `bool` corrupts the value stack — when `OpMap` tries to pop a string key, it gets the leftover bool instead.

The forward `emitLoop` avoids this by using `OpJumpIfEnd`, which checks `scope.Index` directly without touching the stack.

**Fix:**
Add `OpPop` after `OpJumpIfFalse` (continue path) and after `patchJump` (exit path). This matches the convention used by `emitCond` and every other `OpJumpIfFalse` callsite in the compiler.

**After fix:**
```go
expr.Eval(`{"r": findLast([1, 2, 3, 4, 5], # > 3)}`, nil)
// => map[r:5]
```

**Validation:**
- Full test suite passes (60+ packages)
- Added regression tests covering: findLast/findLastIndex in map literals, no-match case, multiple backward-iterating builtins in one map