### PR TITLE
fix: support ConstExpr with functions defined via expr.Function

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -74,6 +74,22 @@ func (c *Config) WithEnv(env any) {
 }
 
 func (c *Config) ConstExpr(name string) {
+	// Check if the function is defined via expr.Function first.
+	if fn, ok := c.Functions[name]; ok {
+		if fn.Func != nil {
+			c.ConstFns[name] = reflect.ValueOf(fn.Func)
+			return
+		}
+		if fn.Fast != nil {
+			c.ConstFns[name] = reflect.ValueOf(fn.Fast)
+			return
+		}
+		if fn.Safe != nil {
+			c.ConstFns[name] = reflect.ValueOf(fn.Safe)
+			return
+		}
+		panic(fmt.Errorf("const expression %q must have a function implementation", name))
+	}
 	if c.EnvObject == nil {
 		panic("no environment is specified for ConstExpr()")
 	}


### PR DESCRIPTION
Fixes #809

## Problem

`expr.ConstExpr("fn")` panics when `fn` was defined using `expr.Function()` instead of being a method on the environment struct:

```go
expr.Function("identity", func(params ...any) (any, error) {
    return params[0], nil
}, new(func(any) any))

expr.Compile(`identity(1)`, expr.ConstExpr("identity")) // panic!
```

This is because `ConstExpr` only looks in the environment object via `runtime.Fetch`, not in the `Functions` table populated by `expr.Function()`.

## Fix

Check `c.Functions` first and extract the appropriate function implementation (`Func`, `Fast`, or `Safe`) before falling back to the environment object lookup.