### PR TITLE
fix(vm): clear error when fetching field from string at runtime

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -1586,6 +1586,14 @@ func TestExpr_fetch_from_func(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot fetch Value from func()")
 }
 
+func TestExpr_fetch_field_from_string(t *testing.T) {
+	// Accessing a named field on a string value (via dynamic map lookup) should
+	// produce a clear error instead of "invalid operation: int(string)".
+	_, err := expr.Eval(`let v = {"k": "hello"}; v.k.missing != ""`, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot fetch missing from string")
+}
+
 func TestExpr_map_default_values(t *testing.T) {
 	env := map[string]any{
 		"foo": map[string]string{},

--- a/vm/runtime/runtime.go
+++ b/vm/runtime/runtime.go
@@ -42,6 +42,9 @@ func Fetch(from, i any) any {
 
 	switch v.Kind() {
 	case reflect.Array, reflect.Slice, reflect.String:
+		if _, ok := i.(string); ok {
+			panic(fmt.Sprintf("cannot fetch %v from %T", i, from))
+		}
 		index := ToInt(i)
 		l := v.Len()
 		if index < 0 {


### PR DESCRIPTION
When a map value resolves to a string at runtime and is followed by a named-field access (e.g. `v.k.missing` where `v.k` is a string), the `Fetch` helper falls into the `Array/Slice/String` branch and calls `ToInt` on the field name. `ToInt` panics with `invalid operation: int(string)`, which is confusing for users expecting `type string has no field X`.

Guard the branch: if the index is a string it can only be a property name, not an integer index, so panic with the canonical `cannot fetch <field> from <type>` message.

Fixes #962.