### PR TITLE
reject non-comparable keys in fromPairs

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -791,6 +791,9 @@ var Builtins = []*Function{
 				}
 				key := pair.Index(0)
 				value := pair.Index(1)
+				if k := key.Interface(); k != nil && !reflect.TypeOf(k).Comparable() {
+					return nil, fmt.Errorf("cannot use %T as a key for fromPairs: type is not comparable", k)
+				}
 				out.SetMapIndex(key, value)
 			}
 			return out.Interface(), nil

--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -284,6 +284,7 @@ func TestBuiltin_errors(t *testing.T) {
 		{`flatten([1, 2], [3, 4])`, "invalid number of arguments (expected 1, got 2)"},
 		{`flatten(1)`, "cannot flatten int"},
 		{`fromJSON("5e2482")`, "cannot unmarshal number"},
+		{`fromPairs([[[1, 2], 3]])`, "cannot use []interface {} as a key for fromPairs: type is not comparable"},
 	}
 	for _, test := range errorTests {
 		t.Run(test.input, func(t *testing.T) {

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -66,6 +66,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`invalid order .*, expected asc or desc`),
 		regexp.MustCompile(`unknown order, use asc or desc`),
 		regexp.MustCompile(`cannot use .* as a key for groupBy: type is not comparable`),
+		regexp.MustCompile(`cannot use .* as a key for fromPairs: type is not comparable`),
 	}
 
 	env := NewEnv()


### PR DESCRIPTION
fromPairs builds a map[any]any, so a pair whose key is a slice or
map hits a raw "hash of unhashable type" runtime panic. Check the
key is comparable before SetMapIndex and return an error instead,
matching the groupBy handling added in #940.