### PR TITLE
fix(builtin): reject negative count in take

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -657,6 +657,9 @@ var Builtins = []*Function{
 			if !n.CanInt() {
 				return nil, fmt.Errorf("cannot take %s elements", n.Kind())
 			}
+			if n.Int() < 0 {
+				return nil, fmt.Errorf("cannot take negative number of elements (got %d)", n.Int())
+			}
 			to := 0
 			if n.Int() > int64(v.Len()) {
 				to = v.Len()

--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -271,6 +271,7 @@ func TestBuiltin_errors(t *testing.T) {
 		{`date("error")`, `invalid date`},
 		{`get()`, `invalid number of arguments (expected 2, got 0)`},
 		{`get(1, 2)`, `type int does not support indexing`},
+		{`take([1, 2, 3], -1)`, "cannot take negative number of elements (got -1)"},
 		{`bitnot("1")`, "cannot use string as argument (type int) to call bitnot  (1:8)"},
 		{`bitand("1", 1)`, "cannot use string as argument (type int) to call bitand  (1:8)"},
 		{`"10" | bitor(1)`, "cannot use string as argument (type int) to call bitor  (1:1)"},

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -66,6 +66,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`invalid order .*, expected asc or desc`),
 		regexp.MustCompile(`unknown order, use asc or desc`),
 		regexp.MustCompile(`cannot use .* as a key for groupBy: type is not comparable`),
+		regexp.MustCompile(`cannot take negative number of elements`),
 	}
 
 	env := NewEnv()


### PR DESCRIPTION
take([1,2,3], -1) surfaces a raw reflect.Value.Slice "slice index
out of bounds" runtime error. The negative count skips the > v.Len()
clamp and reaches v.Slice(0, -1) unmodified. Reject n < 0 the same
way repeat does and return a descriptive error.