### PR TITLE
return error on non-string element in join

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -337,7 +337,11 @@ var Builtins = []*Function{
 			case []any:
 				var s []string
 				for _, arg := range args[0].([]any) {
-					s = append(s, arg.(string))
+					str, ok := arg.(string)
+					if !ok {
+						return nil, fmt.Errorf("invalid argument for join (type %s)", reflect.TypeOf(arg))
+					}
+					s = append(s, str)
 				}
 				return strings.Join(s, glue), nil
 			}

--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -281,6 +281,7 @@ func TestBuiltin_errors(t *testing.T) {
 		{`now(nil)`, "invalid number of arguments (expected 0, got 1)"},
 		{`date(nil)`, "interface {} is nil, not string (1:1)"},
 		{`timezone(nil)`, "cannot use nil as argument (type string) to call timezone (1:10)"},
+		{`join([1, 2])`, "invalid argument for join (type int)"},
 		{`flatten([1, 2], [3, 4])`, "invalid number of arguments (expected 1, got 2)"},
 		{`flatten(1)`, "cannot flatten int"},
 		{`fromJSON("5e2482")`, "cannot unmarshal number"},


### PR DESCRIPTION
join([1,2]) hits arg.(string) on the []any branch and surfaces a raw "interface conversion: interface {} is int, not string" runtime error instead of the invalid argument for join error the other branches return. Check the assertion and return that error.