### PR TITLE
return error from date when only a location is given

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -517,6 +517,10 @@ var Builtins = []*Function{
 				args = args[1:]
 			}
 
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected at least 1, got 0)")
+			}
+
 			date := args[0].(string)
 			if len(args) == 2 {
 				layout := args[1].(string)

--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -280,6 +280,7 @@ func TestBuiltin_errors(t *testing.T) {
 		{`bitushr(-5, -2)`, "invalid operation: negative shift count -2 (type int) (1:1)"},
 		{`now(nil)`, "invalid number of arguments (expected 0, got 1)"},
 		{`date(nil)`, "interface {} is nil, not string (1:1)"},
+		{`date(timezone("UTC"))`, "invalid number of arguments (expected at least 1, got 0)"},
 		{`timezone(nil)`, "cannot use nil as argument (type string) to call timezone (1:10)"},
 		{`flatten([1, 2], [3, 4])`, "invalid number of arguments (expected 1, got 2)"},
 		{`flatten(1)`, "cannot flatten int"},


### PR DESCRIPTION
date(timezone("UTC")) strips the location then reads args[0] unchecked, panicking with a raw index-out-of-range; return the usual arg-count error instead.