### PR TITLE
check struct field name is a string in Fetch and get

### DIFF
--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -211,6 +211,18 @@ func TestBuiltin(t *testing.T) {
 	}
 }
 
+func TestBuiltin_get_struct_non_string_key(t *testing.T) {
+	type anyEnv struct{ Foo any }
+	env := anyEnv{Foo: mock.Foo{Value: "a"}}
+
+	program, err := expr.Compile(`get(Foo, 1)`, expr.Env(env))
+	require.NoError(t, err)
+
+	out, err := expr.Run(program, env)
+	require.NoError(t, err)
+	require.Nil(t, out)
+}
+
 func TestBuiltin_works_with_any(t *testing.T) {
 	config := map[string]struct {
 		arity int
@@ -874,10 +886,10 @@ func TestAbs_UnsignedIntegers(t *testing.T) {
 	// Test that abs() correctly handles unsigned integers
 	// Unsigned integers are always non-negative, so abs() should return them unchanged
 	tests := []struct {
-		name  string
-		env   map[string]any
-		expr  string
-		want  any
+		name string
+		env  map[string]any
+		expr string
+		want any
 	}{
 		{"uint", map[string]any{"x": uint(42)}, "abs(x)", uint(42)},
 		{"uint8", map[string]any{"x": uint8(42)}, "abs(x)", uint8(42)},

--- a/builtin/lib.go
+++ b/builtin/lib.go
@@ -595,7 +595,10 @@ func get(params ...any) (out any, err error) {
 		}
 
 	case reflect.Struct:
-		fieldName := i.(string)
+		fieldName, ok := i.(string)
+		if !ok {
+			break
+		}
 		t := v.Type()
 		field, ok := t.FieldByNameFunc(func(name string) bool {
 			f, _ := t.FieldByName(name)

--- a/vm/runtime/runtime.go
+++ b/vm/runtime/runtime.go
@@ -73,7 +73,10 @@ func Fetch(from, i any) any {
 		}
 
 	case reflect.Struct:
-		fieldName := i.(string)
+		fieldName, ok := i.(string)
+		if !ok {
+			break
+		}
 		t := v.Type()
 		key := fieldCacheKey{
 			t: t,

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -212,6 +212,22 @@ func TestRun_MethodWithError(t *testing.T) {
 	require.Equal(t, "error", selfErr.Error())
 }
 
+func TestRun_FetchStructNonStringKey(t *testing.T) {
+	type Foo struct{ Value string }
+	type anyEnv struct {
+		Foo any
+		I   any
+	}
+	env := anyEnv{Foo: Foo{Value: "a"}, I: 1}
+
+	program, err := expr.Compile(`Foo[I]`, expr.Env(env))
+	require.NoError(t, err)
+
+	_, err = expr.Run(program, env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot fetch")
+}
+
 func TestRun_FastMethods(t *testing.T) {
 	input := `hello() + world()`
 


### PR DESCRIPTION
runtime.Fetch (runtime.go:76) and the get builtin (lib.go:598) read a struct field name with an unchecked i.(string), so indexing a struct held in an any value with a non-string key panics with a raw interface conversion. Use a checked assertion so Fetch falls through to its usual "cannot fetch" error and get returns nil per its no-panic contract.