### PR TITLE
fix: support pointer-to-map env without panic

### DIFF
--- a/conf/env.go
+++ b/conf/env.go
@@ -30,24 +30,25 @@ func EnvWithCache(c *Cache, env any) Nature {
 	}
 
 	v := reflect.ValueOf(env)
+	d := deref.Value(v)
 	t := v.Type()
 
-	switch deref.Value(v).Kind() {
+	switch d.Kind() {
 	case reflect.Struct:
 		n := c.FromType(t)
 		n.Strict = true
 		return n
 
 	case reflect.Map:
-		n := c.FromType(v.Type())
+		n := c.FromType(d.Type())
 		if n.TypeData == nil {
 			n.TypeData = new(TypeData)
 		}
 		n.Strict = true
-		n.Fields = make(map[string]Nature, v.Len())
+		n.Fields = make(map[string]Nature, d.Len())
 
-		for _, key := range v.MapKeys() {
-			elem := v.MapIndex(key)
+		for _, key := range d.MapKeys() {
+			elem := d.MapIndex(key)
 			if !elem.IsValid() || !elem.CanInterface() {
 				panic(fmt.Sprintf("invalid map value: %s", key))
 			}

--- a/test/issues/825/issue_test.go
+++ b/test/issues/825/issue_test.go
@@ -1,0 +1,20 @@
+package issue_test
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/internal/testify/require"
+)
+
+func TestIssue825(t *testing.T) {
+	m := map[string]any{"foo": 42}
+	env := &m
+
+	prog, err := expr.Compile("foo > 0", expr.Env(env))
+	require.NoError(t, err)
+
+	out, err := expr.Run(prog, env)
+	require.NoError(t, err)
+	require.Equal(t, true, out)
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -52,6 +52,12 @@ type VM struct {
 }
 
 func (vm *VM) Run(program *Program, env any) (_ any, err error) {
+	// Allow pointer-to-map envs (e.g. *map[string]any) so OpLoadFast and
+	// map field access see a concrete map value (#825).
+	if m, ok := env.(*map[string]any); ok && m != nil {
+		env = *m
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			var location file.Location


### PR DESCRIPTION
## Summary
Passing `*map[string]any` to `expr.Env` panicked:

```text
reflect: call of reflect.Value.Len on ptr to non-array Value
```

`conf.EnvWithCache` only used `deref.Value` for the `Kind` switch, then still called `v.Len()` / `v.MapKeys()` on the original pointer.

## Fix
- Build map field metadata from the deref'd value in `conf/env.go`
- Unwrap `*map[string]any` in `vm.Run` so map env optimizations work at runtime

## Test plan
- [x] `go test ./test/issues/825/`
- [x] `go test ./...` (repo suite green)

Fixes #825
